### PR TITLE
[feat]: 게시글 작성 기능 구현 및 테스트

### DIFF
--- a/src/main/java/com/backend/domain/board/constant/BoardType.java
+++ b/src/main/java/com/backend/domain/board/constant/BoardType.java
@@ -1,0 +1,8 @@
+package com.backend.domain.board.constant;
+
+// 게시판 타입을 정의하는 Enum
+public enum BoardType {
+    NOTICE, // 공지사항
+    QNA,    // Q&A
+    FAQ     // 자주 묻는 질문
+}

--- a/src/main/java/com/backend/domain/board/controller/ApiV1BoardController.java
+++ b/src/main/java/com/backend/domain/board/controller/ApiV1BoardController.java
@@ -1,0 +1,50 @@
+package com.backend.domain.board.controller;
+
+import com.backend.domain.board.dto.request.BoardWriteRequest;
+import com.backend.domain.board.dto.response.BoardWriteResponse;
+import com.backend.domain.board.entity.Board;
+import com.backend.domain.board.service.BoardService;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/boards")
+@Tag(name = "게시글", description = "게시글 작성, 조회, 수정, 삭제 관련 API")
+public class ApiV1BoardController {
+
+    private final BoardService boardService;
+    private final MemberRepository memberRepository; // MemberRepository 주입
+
+
+    @PostMapping
+    @Operation(summary = "게시글 작성")
+    @ApiResponse(responseCode = "201", description = "게시글이 작성되었습니다.")
+    public ResponseEntity<RsData<BoardWriteResponse>> writeBoard(@RequestBody BoardWriteRequest request) {
+
+        // 현재는 임시 Member 객체를 생성하여 사용..
+        Member member = memberRepository.findById(1L)
+                .orElseThrow(() -> new RuntimeException("1번 회원을 찾을 수 없습니다."));
+
+        // 게시글 생성..
+        Board createdBoard = boardService.create(request, member);
+
+        // 응답 DTO 생성..
+        BoardWriteResponse data = BoardWriteResponse.from(createdBoard);
+
+        // 최종 응답 형태 생성..
+        RsData<BoardWriteResponse> response = new RsData<>("201", "게시글이 작성되었습니다", data);
+        return ResponseEntity.status(201).body(response);
+    }
+}
+

--- a/src/main/java/com/backend/domain/board/dto/request/BoardWriteRequest.java
+++ b/src/main/java/com/backend/domain/board/dto/request/BoardWriteRequest.java
@@ -1,0 +1,23 @@
+package com.backend.domain.board.dto.request;
+
+import com.backend.domain.board.constant.BoardType;
+import com.backend.domain.board.entity.Board;
+import com.backend.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardWriteRequest {
+
+    private String title;
+    private String content;
+    private BoardType boardType;
+
+    // DTO를 Board 엔티티로 변환하는 메서드
+    public Board toEntity(Member member) {
+        return new Board(this.title, this.content, this.boardType, member, null);
+    }
+}

--- a/src/main/java/com/backend/domain/board/dto/response/BoardWriteResponse.java
+++ b/src/main/java/com/backend/domain/board/dto/response/BoardWriteResponse.java
@@ -1,0 +1,31 @@
+package com.backend.domain.board.dto.response;
+
+import com.backend.domain.board.constant.BoardType;
+import com.backend.domain.board.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardWriteResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private BoardType boardType;
+
+    // Board 엔티티를 DTO로 변환하는 정적 팩토리 메서드
+    public static BoardWriteResponse from(Board board) {
+        return BoardWriteResponse.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .boardType(board.getBoardType())
+                .build();
+    }
+}
+

--- a/src/main/java/com/backend/domain/board/entity/Board.java
+++ b/src/main/java/com/backend/domain/board/entity/Board.java
@@ -1,5 +1,6 @@
 package com.backend.domain.board.entity;
 
+import com.backend.domain.board.constant.BoardType;
 import com.backend.domain.comment.entity.Comment;
 import com.backend.domain.member.entity.Member;
 import com.backend.global.jpa.entity.BaseEntity;
@@ -20,8 +21,9 @@ public class Board extends BaseEntity {
     @Column(nullable = false, length = 255)
     private String content;
 
+    @Enumerated(EnumType.STRING) // Enum 타입을 DB에 문자열로 저장..
     @Column(name = "board_type", length = 50)
-    private String boardType;
+    private BoardType boardType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", insertable = false, updatable = false)

--- a/src/main/java/com/backend/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/backend/domain/board/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.backend.domain.board.repository;
+
+import com.backend.domain.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/backend/domain/board/service/BoardService.java
@@ -1,0 +1,25 @@
+package com.backend.domain.board.service;
+
+import com.backend.domain.board.dto.request.BoardWriteRequest;
+import com.backend.domain.board.entity.Board;
+import com.backend.domain.board.repository.BoardRepository;
+import com.backend.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    // 게시글 생성 로직
+    @Transactional
+    public Board create(BoardWriteRequest request, Member member) {
+        // 요청 DTO와 사용자 정보를 바탕으로 Board 엔티티 생성..
+        Board board = request.toEntity(member);
+        return boardRepository.save(board);
+    }
+}
+

--- a/src/test/java/com/backend/domain/board/controller/ApiV1BoardControllerTest.java
+++ b/src/test/java/com/backend/domain/board/controller/ApiV1BoardControllerTest.java
@@ -1,0 +1,77 @@
+package com.backend.domain.board.controller;
+
+import com.backend.domain.board.constant.BoardType;
+import com.backend.domain.board.dto.request.BoardWriteRequest;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test") // 테스트용 프로파일 활성화..
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ApiV1BoardControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = new Member();
+        testMember.setEmail("test@test.com");
+        testMember.setPassword("password");
+        memberRepository.save(testMember);
+    }
+
+    @Test
+    @DisplayName("게시글 작성 성공 - 통합 테스트")
+    void createBoard_success() throws Exception {
+        // given..
+        BoardWriteRequest request = new BoardWriteRequest(
+                "통합 테스트 제목",
+                "통합 테스트 내용입니다.",
+                BoardType.FAQ
+        );
+
+        // when..
+        ResultActions resultActions = mvc
+                .perform(post("/api/v1/boards")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+
+        // then..
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.resultCode").value("201"))
+                .andExpect(jsonPath("$.msg").value("게시글이 작성되었습니다"))
+                .andExpect(jsonPath("$.data.id").isNumber()) // ID가 생성되었는지 확인
+                .andExpect(jsonPath("$.data.title").value("통합 테스트 제목"))
+                .andExpect(jsonPath("$.data.content").value("통합 테스트 내용입니다."));
+    }
+}
+

--- a/src/test/java/com/backend/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/com/backend/domain/board/service/BoardServiceTest.java
@@ -1,0 +1,61 @@
+package com.backend.domain.board.service;
+
+import com.backend.domain.board.constant.BoardType;
+import com.backend.domain.board.dto.request.BoardWriteRequest;
+import com.backend.domain.board.entity.Board;
+import com.backend.domain.board.repository.BoardRepository;
+import com.backend.domain.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+    @InjectMocks
+    private BoardService boardService;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("게시글 생성 로직 테스트")
+    void createBoard_success() {
+        // given..
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(1L);
+
+        BoardWriteRequest request = new BoardWriteRequest(
+                "테스트 제목",
+                "테스트 내용입니다.",
+                BoardType.NOTICE
+        );
+        Board savedBoard = request.toEntity(member);
+        given(boardRepository.save(any(Board.class))).willReturn(savedBoard);
+
+
+        // when..
+        Board resultBoard = boardService.create(request, member);
+
+        // then..
+        // 반환된 결과가 null이 아닌지 확인..
+        assertThat(resultBoard).isNotNull();
+        // 요청했던 제목과 반환된 제목이 일치하는지 확인..
+        assertThat(resultBoard.getTitle()).isEqualTo(request.getTitle());
+        // 요청했던 내용과 반환된 내용이 일치하는지 확인..
+        assertThat(resultBoard.getContent()).isEqualTo(request.getContent());
+        // 작성자 정보가 올바르게 연결되었는지 확인..
+        assertThat(resultBoard.getMember().getId()).isEqualTo(1L);
+        verify(boardRepository).save(any(Board.class));
+    }
+}
+


### PR DESCRIPTION
- 게시글 작성 API 구현
  - POST /api/v1/boards 엔드포인트를 구현했습니다..
  - Controller, Service, Repository, DTO(Request/Response) 계층을 설계하고 작성했습니다..
  - 게시판 타입을 관리하기 위해 BoardType Enum을 도입하고 엔티티에 적용했습니다..

- 통합 테스트 코드 작성
  - @SpringBootTest를 사용하여 게시글 작성 API의 전체 흐름을 검증하는 통합 테스트를 작성했습니다..

이제 속도 내보겠습니다..!