### PR TITLE
[Feat]: 낙찰 결제 로직 추가, 지갑 출금 연동 (서비스 테스트 통과)

### DIFF
--- a/src/main/java/com/backend/domain/bid/controller/ApiV1BidController.java
+++ b/src/main/java/com/backend/domain/bid/controller/ApiV1BidController.java
@@ -1,9 +1,6 @@
 package com.backend.domain.bid.controller;
 
-import com.backend.domain.bid.dto.BidCurrentResponseDto;
-import com.backend.domain.bid.dto.BidRequestDto;
-import com.backend.domain.bid.dto.BidResponseDto;
-import com.backend.domain.bid.dto.MyBidResponseDto;
+import com.backend.domain.bid.dto.*;
 import com.backend.domain.bid.service.BidService;
 import com.backend.domain.member.repository.MemberRepository;
 import com.backend.global.response.RsData;
@@ -16,9 +13,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @Tag(name = "Bid", description = "입찰 관련 API")
 @RestController
@@ -86,4 +85,23 @@ public class ApiV1BidController {
         return bidService.getMyBids(memberId,page,size);
     }
 
+    @Operation(summary = "낙찰 결제", description = "내가 낙찰한 입찰 건에 대해 지갑에서 출금하고 결제 완료로 표시합니다.")
+    @PostMapping("/{bidId}/pay")
+    public RsData<BidPayResponseDto> payBid(
+            @PathVariable Long bidId,
+            @AuthenticationPrincipal User user
+    ) {
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        Long memberId;
+        try {
+            memberId = Long.parseLong(user.getUsername());
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다.");
+        }
+
+        return bidService.payForBid(memberId, bidId);
+    }
 }

--- a/src/main/java/com/backend/domain/bid/dto/BidPayResponseDto.java
+++ b/src/main/java/com/backend/domain/bid/dto/BidPayResponseDto.java
@@ -1,0 +1,12 @@
+package com.backend.domain.bid.dto;
+
+import java.time.LocalDateTime;
+
+public record BidPayResponseDto(
+        Long bidId,
+        Long productId,
+        Long amount,
+        LocalDateTime paidAt,
+        Long cashTransactionId,
+        Long balanceAfter
+) {}

--- a/src/main/java/com/backend/domain/bid/entity/Bid.java
+++ b/src/main/java/com/backend/domain/bid/entity/Bid.java
@@ -6,6 +6,8 @@ import com.backend.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "bids")
 @Getter @Setter
@@ -27,4 +29,10 @@ public class Bid extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bidder_id")
     private Member member;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Column(name = "paid_amount")
+    private Long paidAmount;
 }

--- a/src/test/java/com/backend/domain/bid/service/BidPayServiceTest.java
+++ b/src/test/java/com/backend/domain/bid/service/BidPayServiceTest.java
@@ -1,0 +1,160 @@
+package com.backend.domain.bid.service;
+
+import com.backend.domain.bid.dto.BidPayResponseDto;
+import com.backend.domain.bid.entity.Bid;
+import com.backend.domain.bid.repository.BidRepository;
+import com.backend.domain.cash.entity.Cash;
+import com.backend.domain.cash.repository.CashRepository;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.product.entity.Product;
+import com.backend.domain.product.enums.AuctionStatus;
+import com.backend.domain.product.enums.DeliveryMethod;
+import com.backend.domain.product.enums.ProductCategory;
+import com.backend.global.exception.ServiceException;
+import com.backend.global.response.RsData;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class BidPayServiceTest {
+
+    @Autowired BidService bidService;
+    @Autowired BidRepository bidRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired CashRepository cashRepository;
+    @Autowired EntityManager em;
+
+    Member me;         // 입찰자(구매자)
+    Member seller;     // 판매자(상품의 seller)
+    Product product;   // 낙찰 상태의 상품
+
+    @BeforeEach
+    void setUp() {
+        // 1) 회원(구매자/판매자) 생성
+        seller = memberRepository.save(
+                Member.builder()
+                        .email("seller@test.com")
+                        .password("pw!")
+                        .nickname("seller")
+                        .build()
+        );
+        me = memberRepository.save(
+                Member.builder()
+                        .email("winner@test.com")
+                        .password("pw!")
+                        .nickname("winner")
+                        .build()
+        );
+
+        // 2) Product는 생성자 필수값이 많으니 "생성자"로 만든다.
+        LocalDateTime start = LocalDateTime.now().minusHours(2); // 이미 시작
+        Integer durationHrs = 1; // 1시간 경매 → 이미 종료로 간주
+        product = new Product(
+                "테스트 상품",
+                "설명",
+                ProductCategory.values()[0],  // 프로젝트 실제 카테고리로 교체 가능
+                1_000L,
+                start,
+                durationHrs,
+                DeliveryMethod.values()[0],   // 프로젝트 실제 배송방법으로 교체 가능
+                "서울",
+                seller
+        );
+        // 상태/현재가만 setter로 덮어쓰기
+        product.setStatus(AuctionStatus.SUCCESSFUL.getDisplayName()); // "낙찰"
+        product.setCurrentPrice(7_000L);
+        em.persist(product);
+
+        // 3) 지갑: 잔액 10_000 (me = 구매자)
+        cashRepository.save(Cash.builder()
+                .member(me)
+                .balance(10_000L)
+                .build());
+    }
+
+    @Test
+    void 낙찰_결제_정상동작() {
+        // 내 입찰(최고가 7_000)
+        Bid myBid = Bid.builder()
+                .bidPrice(7_000L)
+                .status("bidding")
+                .product(product)
+                .member(me)
+                .build();
+        bidRepository.save(myBid);
+
+        // 실행
+        RsData<BidPayResponseDto> rs = bidService.payForBid(me.getId(), myBid.getId());
+
+        // 검증: record 접근자(resultCode()/msg()/data())
+        assertThat(rs.resultCode()).isEqualTo("200");
+        assertThat(rs.data().amount()).isEqualTo(7_000L);
+        assertThat(rs.data().paidAt()).isNotNull();
+        assertThat(rs.data().cashTransactionId()).isNotNull();
+        assertThat(rs.data().balanceAfter()).isEqualTo(3_000L); // 10_000 - 7_000
+    }
+
+    @Test
+    void 이미_결제한_입찰은_멱등_응답() {
+        // 이미 결제된 입찰 만들기
+        Bid bid = Bid.builder()
+                .bidPrice(7_000L)
+                .status("bidding")
+                .product(product)
+                .member(me)
+                .paidAt(LocalDateTime.now())
+                .paidAmount(7_000L)
+                .build();
+        bidRepository.save(bid);
+
+        RsData<BidPayResponseDto> rs = bidService.payForBid(me.getId(), bid.getId());
+
+        assertThat(rs.resultCode()).isEqualTo("200");
+        assertThat(rs.msg()).contains("이미 결제");
+        assertThat(rs.data().amount()).isEqualTo(7_000L);
+        // 간단 버전: cashTransactionId / balanceAfter 는 null일 수 있음
+    }
+
+    @Test
+    void 낙찰상태가_아니면_결제_거부() {
+        // "경매 중" 상품 하나 더 만들어서 실패 유도
+        LocalDateTime start = LocalDateTime.now().minusMinutes(10);
+        Integer durationHrs = 2; // 아직 진행 중
+        Product biddingProduct = new Product(
+                "테스트 상품2",
+                "설명2",
+                ProductCategory.values()[0],
+                2_000L,
+                start,
+                durationHrs,
+                DeliveryMethod.values()[0],
+                "부산",
+                seller
+        );
+        biddingProduct.setStatus(AuctionStatus.BIDDING.getDisplayName()); // "경매 중"
+        biddingProduct.setCurrentPrice(7_000L);
+        em.persist(biddingProduct);
+
+        Bid myBid = Bid.builder()
+                .bidPrice(7_000L)
+                .status("bidding")
+                .product(biddingProduct)
+                .member(me)
+                .build();
+        bidRepository.save(myBid);
+
+        assertThatThrownBy(() -> bidService.payForBid(me.getId(), myBid.getId()))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("낙찰이 확정되지");
+    }
+}

--- a/src/test/java/com/backend/domain/cash/service/CashServiceTest.java
+++ b/src/test/java/com/backend/domain/cash/service/CashServiceTest.java
@@ -1,0 +1,65 @@
+package com.backend.domain.cash.service;
+
+import com.backend.domain.cash.constant.CashTxType;
+import com.backend.domain.cash.constant.RelatedType;
+import com.backend.domain.cash.entity.Cash;
+import com.backend.domain.cash.entity.CashTransaction;
+import com.backend.domain.cash.repository.CashRepository;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CashServiceTest {
+
+    @Autowired CashService cashService;
+    @Autowired CashRepository cashRepository;
+    @Autowired MemberRepository memberRepository;
+
+    @Test
+    void 출금_성공하면_잔액줄고_WITHDRAW원장생성() {
+        // 준비: 회원 + 지갑(잔액 10_000)
+        Member me = memberRepository.save(
+                Member.builder()
+                        .email("me@test.com")
+                        .password("pw!")
+                        .nickname("me")
+                        .build()
+        );
+        Cash cash = cashRepository.save(Cash.builder().member(me).balance(10_000L).build());
+
+        // 실행: 8_000원 출금
+        CashTransaction tx = cashService.withdraw(me, 8_000L, RelatedType.BID, 123L);
+
+        // 검증: 잔액 2_000, WITHDRAW, 금액 8_000, 관련 타입 BID
+        assertThat(cash.getBalance()).isEqualTo(2_000L);
+        assertThat(tx.getType()).isEqualTo(CashTxType.WITHDRAW);
+        assertThat(tx.getAmount()).isEqualTo(8_000L);
+        assertThat(tx.getBalanceAfter()).isEqualTo(2_000L);
+        assertThat(tx.getRelatedType()).isEqualTo(RelatedType.BID);
+        assertThat(tx.getRelatedId()).isEqualTo(123L);
+    }
+
+    @Test
+    void 잔액부족이면_출금_실패() {
+        Member me = memberRepository.save(
+                Member.builder()
+                        .email("me2@test.com")
+                        .password("pw!!")
+                        .nickname("med")
+                        .build()
+        );
+        Cash cash = cashRepository.save(Cash.builder().member(me).balance(5_000L).build());
+
+        // 실행+검증: 8_000 출금 시 예외
+        assertThatThrownBy(() -> cashService.withdraw(me, 8_000L, RelatedType.BID, 1L))
+                .hasMessageContaining("잔액이 부족");
+        assertThat(cash.getBalance()).isEqualTo(5_000L);
+    }
+}


### PR DESCRIPTION
- 낙찰 결제(payForBid) 서비스 로직 구현..
- 지갑 출금(Withdraw)과 원장(CashTransaction) 기록 연동..
- Bid 엔티티에 paidAt, paidAmount 추가..
- 내일 컨트롤러 테스트 추가 예정..