### PR TITLE
[Feat]: 낙찰 결제 흐름 구축 + 테스트 통과

### DIFF
--- a/src/main/java/com/backend/domain/bid/controller/ApiV1BidController.java
+++ b/src/main/java/com/backend/domain/bid/controller/ApiV1BidController.java
@@ -96,10 +96,13 @@ public class ApiV1BidController {
         }
 
         Long memberId;
+        String username = user.getUsername();
         try {
-            memberId = Long.parseLong(user.getUsername());
+            memberId = Long.parseLong(username);
         } catch (NumberFormatException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다.");
+            var me = memberRepository.findByEmail(username)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다."));
+            memberId = me.getId();
         }
 
         return bidService.payForBid(memberId, bidId);

--- a/src/main/java/com/backend/domain/cash/service/CashService.java
+++ b/src/main/java/com/backend/domain/cash/service/CashService.java
@@ -175,7 +175,7 @@ public class CashService {
         // 잔액 부족이면 실패..
         if (current < amount) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잔액이 부족합니다.");
-        }
+         }
 
         // 잔액 차감..
         long newBalance = current - amount;

--- a/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -37,7 +37,8 @@ public class PaymentService {
     private static final long MIN_AMOUNT = 100L;                            // 최소 100원
     private static final long MAX_AMOUNT_PER_TX = 1_000_000L;               // 1회 한도(예시)..
 
-    @Transactional                                                    // 원자성 보장..
+    // 지갑 충전..
+    @Transactional
     public PaymentResponse charge(Member actor, PaymentRequest req) {
 
         // 입력 검증..
@@ -146,6 +147,7 @@ public class PaymentService {
         return toResponse(payment, newBalance, tx.getId());
     }
 
+    // 내 결제 내역 목록..
     @Transactional(readOnly = true)
     public MyPaymentsResponse getMyPayments(Member member, int page1Base, int size) {
         int page0 = Math.max(0, page1Base - 1);
@@ -165,6 +167,7 @@ public class PaymentService {
                 .build();
     }
 
+    // 내 결제 단건 상세..
     private MyPaymentListItemResponse toListItem(Payment p) {
         String provider   = p.getProvider();
         String methodType = p.getMethodType();

--- a/src/test/java/com/backend/domain/bid/controller/BidPayControllerTest.java
+++ b/src/test/java/com/backend/domain/bid/controller/BidPayControllerTest.java
@@ -1,0 +1,123 @@
+package com.backend.domain.bid.controller;
+
+import com.backend.domain.bid.entity.Bid;
+import com.backend.domain.bid.repository.BidRepository;
+import com.backend.domain.cash.entity.Cash;
+import com.backend.domain.cash.repository.CashRepository;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.product.entity.Product;
+import com.backend.domain.product.enums.AuctionStatus;
+import com.backend.domain.product.enums.DeliveryMethod;
+import com.backend.domain.product.enums.ProductCategory;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false) // JWT 등 보안 필터 비활성화(단순화)
+@Transactional
+class BidPayControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired EntityManager em;
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired CashRepository cashRepository;
+    @Autowired BidRepository bidRepository;
+
+    Member seller;
+    Member buyer;
+    Product product; // 낙찰 상태
+    Bid bid;         // buyer의 최고 입찰(= currentPrice)
+
+    @BeforeEach
+    void setUp() {
+        // 1) 판매자/구매자 (password는 NOT NULL)
+        seller = memberRepository.save(
+                Member.builder().email("seller@test.com").password("pw").nickname("seller").build()
+        );
+        buyer = memberRepository.save(
+                Member.builder().email("buyer@test.com").password("pw").nickname("buyer").build()
+        );
+
+        // 2) 상품: 낙찰 상태 + 최고가 7,000
+        LocalDateTime start = LocalDateTime.now().minusHours(2);
+        int duration = 1;
+        product = new Product(
+                "테스트 상품",
+                "설명",
+                ProductCategory.values()[0],
+                1_000L,
+                start,
+                duration,
+                DeliveryMethod.values()[0],
+                "서울",
+                seller
+        );
+        product.setStatus(AuctionStatus.SUCCESSFUL.getDisplayName()); // "낙찰"
+        product.setCurrentPrice(7_000L);
+        em.persist(product);
+
+        // 3) 지갑: 10,000
+        cashRepository.save(Cash.builder().member(buyer).balance(10_000L).build());
+
+        // 4) 내 최고 입찰(7,000)
+        bid = bidRepository.save(
+                Bid.builder().product(product).member(buyer).bidPrice(7_000L).status("bidding").build()
+        );
+    }
+
+    @Test
+    @WithMockUser(username = "buyer@test.com") // 컨트롤러가 이메일/숫자 둘 다 지원
+    void 낙찰_결제_API_성공_200_RsData형식() throws Exception {
+        mvc.perform(post("/api/v1/bids/{bidId}/pay", bid.getId()))
+                .andDo(print())
+                // GlobalExceptionHandler를 안 타는 정상 플로우 → 200대 resultCode
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode", startsWith("200")))
+                .andExpect(jsonPath("$.msg", notNullValue()))
+                .andExpect(jsonPath("$.data.amount", is(7_000)))
+                .andExpect(jsonPath("$.data.balanceAfter", is(3_000)))
+                .andExpect(jsonPath("$.data.paidAt", notNullValue()))
+                .andExpect(jsonPath("$.data.cashTransactionId", notNullValue()));
+    }
+
+    @Test
+    void 인증_없으면_401_바디검증없이상태만() throws Exception {
+        // 컨트롤러에서 ResponseStatusException(401)을 던지며,
+        // 이 경우 기본 핸들링으로 바디가 비어있을 수 있으니 상태코드만 확인
+        mvc.perform(post("/api/v1/bids/{bidId}/pay", bid.getId()))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "buyer@test.com")
+    void 낙찰_상태가_아니면_400_RsData형식으로_msg존재() throws Exception {
+        // 실패 유도: 경매중으로 바꿈
+        product.setStatus(AuctionStatus.BIDDING.getDisplayName()); // "경매 중"
+        em.flush();
+
+        mvc.perform(post("/api/v1/bids/{bidId}/pay", bid.getId()))
+                .andDo(print())
+                // ServiceException("400", "...") → GlobalExceptionHandler 가
+                // status=400, body=RsData(resultCode="400-..." 또는 "400", msg="...") 로 변환
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode", startsWith("400")))
+                .andExpect(jsonPath("$.msg", containsString("낙찰이 확정되지"))); // 서비스 예외 메시지 일부
+    }
+}

--- a/src/test/java/com/backend/domain/cash/controller/ApiV1CashControllerTest.java
+++ b/src/test/java/com/backend/domain/cash/controller/ApiV1CashControllerTest.java
@@ -1,0 +1,176 @@
+package com.backend.domain.cash.controller;
+
+import com.backend.domain.cash.constant.CashTxType;
+import com.backend.domain.cash.constant.RelatedType;
+import com.backend.domain.cash.entity.Cash;
+import com.backend.domain.cash.entity.CashTransaction;
+import com.backend.domain.cash.repository.CashRepository;
+import com.backend.domain.cash.repository.CashTransactionRepository;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false) // JWT 등 보안 필터 비활성화
+@Transactional
+class ApiV1CashControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired CashRepository cashRepository;
+    @Autowired CashTransactionRepository cashTxRepository;
+
+    Member me;
+    Member other;
+    Cash myCash;
+    CashTransaction txDeposit;  // id가 더 작음
+    CashTransaction txWithdraw; // id가 더 큼 (목록에서 먼저 나와야 함)
+
+    @BeforeEach
+    void setUp() {
+        // 회원(비번은 NOT NULL이라 꼭 채움)
+        me = memberRepository.save(Member.builder()
+                .email("me@test.com").password("pw").nickname("me").build());
+        other = memberRepository.save(Member.builder()
+                .email("other@test.com").password("pw").nickname("other").build());
+
+        // 내 지갑(잔액 10,000)
+        myCash = cashRepository.save(Cash.builder().member(me).balance(10_000L).build());
+
+        // 원장 2건: 입금(10,000) → 출금(3,000) (정상 흐름)
+        txDeposit = cashTxRepository.save(CashTransaction.builder()
+                .cash(myCash)
+                .type(CashTxType.DEPOSIT)
+                .amount(10_000L)
+                .balanceAfter(10_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(101L) // 임의 값
+                .build());
+
+        txWithdraw = cashTxRepository.save(CashTransaction.builder()
+                .cash(myCash)
+                .type(CashTxType.WITHDRAW)
+                .amount(3_000L)
+                .balanceAfter(7_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(102L) // 임의 값
+                .build());
+
+        // other 유저의 지갑/원장(권한 차단 테스트용)
+        Cash otherCash = cashRepository.save(Cash.builder().member(other).balance(5_000L).build());
+        cashTxRepository.save(CashTransaction.builder()
+                .cash(otherCash)
+                .type(CashTxType.DEPOSIT)
+                .amount(5_000L)
+                .balanceAfter(5_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(201L)
+                .build());
+    }
+
+    // ============ /api/v1/cash ============
+    @Test
+    @WithMockUser(username = "me@test.com") // 컨트롤러는 email로 회원 조회
+    void 내_지갑_조회_200() throws Exception {
+        mvc.perform(get("/api/v1/cash"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberId", is(me.getId().intValue())))
+                .andExpect(jsonPath("$.cashId", is(myCash.getId().intValue())))
+                .andExpect(jsonPath("$.balance", is(10_000)))
+                .andExpect(jsonPath("$.createDate", notNullValue()))
+                .andExpect(jsonPath("$.modifyDate", notNullValue()));
+    }
+
+    @Test
+    void 내_지갑_조회_인증없으면_401() throws Exception {
+        // GlobalExceptionHandler가 ResponseStatusException을 RsData로 변환하진 않으므로
+        // 여기서는 상태코드만 검사
+        mvc.perform(get("/api/v1/cash"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ============ /api/v1/cash/transactions ============
+    @Test
+    @WithMockUser(username = "me@test.com")
+    void 내_원장_목록_200_정렬검증() throws Exception {
+        mvc.perform(get("/api/v1/cash/transactions")
+                        .param("page", "1")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page", is(1)))
+                .andExpect(jsonPath("$.size", is(20)))
+                .andExpect(jsonPath("$.total", is(2)))
+                .andExpect(jsonPath("$.items", hasSize(2)))
+                // 최신(id DESC) → 출금(7000) 먼저
+                .andExpect(jsonPath("$.items[0].type", is("WITHDRAW")))
+                .andExpect(jsonPath("$.items[0].amount", is(3_000)))
+                .andExpect(jsonPath("$.items[0].balanceAfter", is(7_000)))
+                .andExpect(jsonPath("$.items[0].related.type", is("PAYMENT")))
+                .andExpect(jsonPath("$.items[0].related.id", is(102)))
+
+                // 그 다음 입금(10000)
+                .andExpect(jsonPath("$.items[1].type", is("DEPOSIT")))
+                .andExpect(jsonPath("$.items[1].amount", is(10_000)))
+                .andExpect(jsonPath("$.items[1].balanceAfter", is(10_000)))
+                .andExpect(jsonPath("$.items[1].related.type", is("PAYMENT")))
+                .andExpect(jsonPath("$.items[1].related.id", is(101)));
+    }
+
+    @Test
+    void 내_원장_목록_인증없으면_401() throws Exception {
+        mvc.perform(get("/api/v1/cash/transactions"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ============ /api/v1/cash/transactions/{id} ============
+    @Test
+    @WithMockUser(username = "me@test.com")
+    void 내_원장_단건_상세_200_링크존재() throws Exception {
+        mvc.perform(get("/api/v1/cash/transactions/{id}", txWithdraw.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.transactionId", is(txWithdraw.getId().intValue())))
+                .andExpect(jsonPath("$.cashId", is(myCash.getId().intValue())))
+                .andExpect(jsonPath("$.type", is("WITHDRAW")))
+                .andExpect(jsonPath("$.amount", is(3_000)))
+                .andExpect(jsonPath("$.balanceAfter", is(7_000)))
+                .andExpect(jsonPath("$.createdAt", notNullValue()))
+                // Related + Links (PAYMENT면 paymentDetail 링크 생성)
+                .andExpect(jsonPath("$.related.type", is("PAYMENT")))
+                .andExpect(jsonPath("$.related.id", is(102)))
+                .andExpect(jsonPath("$.related.links.paymentDetail", is("/api/v1/payments/me/102")));
+    }
+
+    @Test
+    @WithMockUser(username = "me@test.com")
+    void 다른사람_원장_단건_조회시_404() throws Exception {
+        // other 유저의 트랜잭션 id를 찾아서 접근 시도
+        Long othersTxId = cashTxRepository.findAll().stream()
+                .filter(tx -> tx.getCash().getMember().getId().equals(other.getId()))
+                .map(CashTransaction::getId)
+                .findFirst()
+                .orElseThrow();
+
+        // CashService는 ResponseStatusException(404)을 던짐 → 전역 핸들러가 RsData로 바꾸지 않으므로 상태만 체크
+        mvc.perform(get("/api/v1/cash/transactions/{id}", othersTxId))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/backend/domain/cash/service/CashServiceTest.java
+++ b/src/test/java/com/backend/domain/cash/service/CashServiceTest.java
@@ -1,16 +1,29 @@
 package com.backend.domain.cash.service;
 
+import com.backend.domain.bid.entity.Bid;
+import com.backend.domain.bid.repository.BidRepository;
 import com.backend.domain.cash.constant.CashTxType;
 import com.backend.domain.cash.constant.RelatedType;
+import com.backend.domain.cash.dto.CashResponse;
+import com.backend.domain.cash.dto.CashTransactionResponse;
+import com.backend.domain.cash.dto.CashTransactionsResponse;
 import com.backend.domain.cash.entity.Cash;
 import com.backend.domain.cash.entity.CashTransaction;
 import com.backend.domain.cash.repository.CashRepository;
+import com.backend.domain.cash.repository.CashTransactionRepository;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.product.entity.Product;
+import com.backend.domain.product.enums.DeliveryMethod;
+import com.backend.domain.product.enums.ProductCategory;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -18,9 +31,24 @@ import static org.assertj.core.api.Assertions.*;
 @Transactional
 class CashServiceTest {
 
-    @Autowired CashService cashService;
-    @Autowired CashRepository cashRepository;
-    @Autowired MemberRepository memberRepository;
+    @Autowired
+    CashService cashService;
+
+    @Autowired
+    CashRepository cashRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CashTransactionRepository cashTransactionRepository;
+
+    @Autowired
+    BidRepository bidRepository;
+
+    @Autowired
+    EntityManager em;
+
 
     @Test
     void 출금_성공하면_잔액줄고_WITHDRAW원장생성() {
@@ -61,5 +89,187 @@ class CashServiceTest {
         assertThatThrownBy(() -> cashService.withdraw(me, 8_000L, RelatedType.BID, 1L))
                 .hasMessageContaining("잔액이 부족");
         assertThat(cash.getBalance()).isEqualTo(5_000L);
+    }
+
+    @Test
+    void 내_지갑_조회_성공() {
+        Member me = memberRepository.save(
+                Member.builder().email("me3@test.com").password("pw").nickname("me3").build()
+        );
+        Cash myCash = cashRepository.save(Cash.builder().member(me).balance(10_000L).build());
+
+        CashResponse res = cashService.getMyCashResponse(me);
+
+        assertThat(res.getCashId()).isEqualTo(myCash.getId());
+        assertThat(res.getMemberId()).isEqualTo(me.getId());
+        assertThat(res.getBalance()).isEqualTo(10_000L);
+        assertThat(res.getCreateDate()).isNotNull();
+        assertThat(res.getModifyDate()).isNotNull();
+    }
+
+    @Test
+    void 지갑_없으면_404() {
+        Member other = memberRepository.save(
+                Member.builder().email("no-wallet@test.com").password("pw").build()
+        );
+
+        assertThatThrownBy(() -> cashService.getMyCashResponse(other))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("지갑이 아직 생성되지 않았습니다.");
+    }
+
+    @Test
+    void 내_원장_목록_정렬_및_페이징() {
+        // 회원 + 지갑
+        Member me = memberRepository.save(
+                Member.builder().email("me4@test.com").password("pw").nickname("me4").build()
+        );
+        Cash myCash = cashRepository.save(Cash.builder().member(me).balance(10_000L).build());
+
+        // 입금 → 출금 (id DESC면 출금이 먼저 나와야 함)
+        CashTransaction txDeposit = cashTransactionRepository.save(CashTransaction.builder()
+                .cash(myCash)
+                .type(CashTxType.DEPOSIT)
+                .amount(10_000L)
+                .balanceAfter(10_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(1001L)
+                .build());
+
+        CashTransaction txWithdraw = cashTransactionRepository.save(CashTransaction.builder()
+                .cash(myCash)
+                .type(CashTxType.WITHDRAW)
+                .amount(3_000L)
+                .balanceAfter(7_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(1002L)
+                .build());
+
+        CashTransactionsResponse res = cashService.getMyTransactions(me, 1, 20);
+
+        assertThat(res.getPage()).isEqualTo(1);
+        assertThat(res.getSize()).isEqualTo(20);
+        assertThat(res.getTotal()).isEqualTo(2);
+        assertThat(res.getItems()).hasSize(2);
+
+        // 0: 출금
+        assertThat(res.getItems().get(0).getType()).isEqualTo("WITHDRAW");
+        assertThat(res.getItems().get(0).getAmount()).isEqualTo(3_000L);
+        assertThat(res.getItems().get(0).getBalanceAfter()).isEqualTo(7_000L);
+        assertThat(res.getItems().get(0).getRelated().getType()).isEqualTo("PAYMENT");
+        assertThat(res.getItems().get(0).getRelated().getId()).isEqualTo(1002L);
+
+        // 1: 입금
+        assertThat(res.getItems().get(1).getType()).isEqualTo("DEPOSIT");
+        assertThat(res.getItems().get(1).getAmount()).isEqualTo(10_000L);
+        assertThat(res.getItems().get(1).getBalanceAfter()).isEqualTo(10_000L);
+        assertThat(res.getItems().get(1).getRelated().getType()).isEqualTo("PAYMENT");
+        assertThat(res.getItems().get(1).getRelated().getId()).isEqualTo(1001L);
+    }
+
+    @Test
+    void 원장_단건_상세_Payment_링크_생성() {
+        // 회원 + 지갑
+        Member me = memberRepository.save(
+                Member.builder().email("me5@test.com").password("pw").nickname("me5").build()
+        );
+        Cash myCash = cashRepository.save(Cash.builder().member(me).balance(10_000L).build());
+
+        // 출금 트랜잭션 (PAYMENT)
+        CashTransaction txWithdraw = cashTransactionRepository.save(CashTransaction.builder()
+                .cash(myCash)
+                .type(CashTxType.WITHDRAW)
+                .amount(3_000L)
+                .balanceAfter(7_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(2002L)
+                .build());
+
+        CashTransactionResponse res = cashService.getMyTransactionDetail(me, txWithdraw.getId());
+
+        assertThat(res.getTransactionId()).isEqualTo(txWithdraw.getId());
+        assertThat(res.getCashId()).isEqualTo(myCash.getId());
+        assertThat(res.getType()).isEqualTo("WITHDRAW");
+        assertThat(res.getAmount()).isEqualTo(3_000L);
+        assertThat(res.getBalanceAfter()).isEqualTo(7_000L);
+        assertThat(res.getCreatedAt()).isNotNull();
+        assertThat(res.getRelated().getType()).isEqualTo("PAYMENT");
+        assertThat(res.getRelated().getId()).isEqualTo(2002L);
+        assertThat(res.getRelated().getLinks().getPaymentDetail())
+                .isEqualTo("/api/v1/payments/me/2002");
+    }
+
+    @Test
+    void 원장_단건_상세_Bid_링크_생성() {
+        // 회원 + 지갑
+        Member me = memberRepository.save(
+                Member.builder().email("me6@test.com").password("pw").nickname("me6").build()
+        );
+        Cash myCash = cashRepository.save(Cash.builder().member(me).balance(10_000L).build());
+
+        // 상품 생성(생성자 정책에 맞춰 값 채움)
+        Product product = new Product(
+                "테스트상품2", "desc",
+                ProductCategory.values()[0],
+                1_000L,
+                LocalDateTime.now().minusHours(1),
+                1,
+                DeliveryMethod.values()[0],
+                "서울",
+                me
+        );
+        em.persist(product);
+
+        // BID 생성
+        Bid bid = bidRepository.save(Bid.builder()
+                .product(product)
+                .member(me)
+                .bidPrice(5_000L)
+                .status("bidding")
+                .build());
+
+        // BID 타입 원장 생성
+        CashTransaction txBid = cashTransactionRepository.save(CashTransaction.builder()
+                .cash(myCash)
+                .type(CashTxType.WITHDRAW)
+                .amount(5_000L)
+                .balanceAfter(5_000L)
+                .relatedType(RelatedType.BID)
+                .relatedId(bid.getId())
+                .build());
+
+        // 상세 조회 → bidDetail 링크 확인
+        CashTransactionResponse res = cashService.getMyTransactionDetail(me, txBid.getId());
+        assertThat(res.getRelated().getType()).isEqualTo("BID");
+        assertThat(res.getRelated().getId()).isEqualTo(bid.getId());
+        assertThat(res.getRelated().getLinks().getBidDetail())
+                .isEqualTo("/api/v1/bids/products/" + product.getId());
+    }
+
+    @Test
+    void 타인_원장_상세_404() {
+        // 내 계정
+        Member me = memberRepository.save(
+                Member.builder().email("me7@test.com").password("pw").nickname("me7").build()
+        );
+        cashRepository.save(Cash.builder().member(me).balance(1_000L).build());
+
+        // 다른 사람 + 지갑 + 트랜잭션
+        Member other = memberRepository.save(
+                Member.builder().email("other@test.com").password("pw").nickname("other").build()
+        );
+        Cash otherCash = cashRepository.save(Cash.builder().member(other).balance(1_000L).build());
+        CashTransaction othersTx = cashTransactionRepository.save(CashTransaction.builder()
+                .cash(otherCash)
+                .type(CashTxType.DEPOSIT)
+                .amount(1_000L)
+                .balanceAfter(1_000L)
+                .relatedType(RelatedType.PAYMENT)
+                .relatedId(9L)
+                .build());
+
+        assertThatThrownBy(() -> cashService.getMyTransactionDetail(me, othersTx.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("원장 내역을 찾을 수 없습니다.");
     }
 }

--- a/src/test/java/com/backend/domain/payment/controller/ApiV1PaymentControllerTest.java
+++ b/src/test/java/com/backend/domain/payment/controller/ApiV1PaymentControllerTest.java
@@ -1,0 +1,258 @@
+package com.backend.domain.payment.controller;
+
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.payment.constant.PaymentMethodType;
+import com.backend.domain.payment.dto.PaymentRequest;
+import com.backend.domain.payment.dto.PgChargeResultResponse;
+import com.backend.domain.payment.dto.TossIssueBillingKeyResponse;
+import com.backend.domain.payment.entity.PaymentMethod;
+import com.backend.domain.payment.repository.PaymentMethodRepository;
+import com.backend.domain.payment.repository.PaymentRepository;
+import com.backend.domain.payment.service.TossBillingClientService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ApiV1PaymentControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper om;
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired PaymentMethodRepository paymentMethodRepository;
+    @Autowired PaymentRepository paymentRepository;
+
+    // 외부 호출은 Mock 처리 (실제 네트워크 X)
+    @MockitoBean
+    TossBillingClientService tossBillingClientService;
+
+    private String email;           // @WithMockUser(username=...) 값과 같아야 함
+    private Member me;
+    private PaymentMethod pmCard;   // 카드 결제수단
+    private String billingKey;
+
+    @BeforeEach
+    void setUp() {
+        email = "pay@test.com";
+        billingKey = "billingKey-123";
+
+        // 회원 저장 (password NOT NULL 이므로 꼭 채워야 함)
+        me = memberRepository.save(
+                Member.builder()
+                        .email(email)
+                        .password("pw!")
+                        .nickname("payer")
+                        .build()
+        );
+
+        // 결제수단 저장 (CARD, token=billingKey)
+        pmCard = paymentMethodRepository.save(
+                PaymentMethod.builder()
+                        .member(me)
+                        .type(PaymentMethodType.CARD)
+                        .token(billingKey)   // 토스 빌링키
+                        .alias("메인카드")
+                        .isDefault(true)
+                        .brand("SHINHAN")
+                        .last4("1234")
+                        .expMonth(12)
+                        .expYear(2030)
+                        .provider("toss")
+                        .active(true)
+                        .deleted(false)
+                        .build()
+        );
+    }
+
+    // 1) 지갑 충전 성공
+    @Test
+    @WithMockUser(username = "pay@test.com") // 컨트롤러가 user.getUsername()으로 email을 읽음
+    void charge_success() throws Exception {
+        // toss 결제 Mock: 성공 응답
+        given(tossBillingClientService.charge(eq(billingKey), eq(5_000L), anyString(), anyString()))
+                .willReturn(PgChargeResultResponse.builder()
+                        .success(true)
+                        .transactionId("payKey_abc123")
+                        .build());
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(pmCard.getId());
+        req.setAmount(5_000L);
+        req.setIdempotencyKey("idem-001");
+
+        mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                // PaymentResponse(JSON) 필드 검증
+                .andExpect(jsonPath("$.paymentId", notNullValue()))
+                .andExpect(jsonPath("$.paymentMethodId", is(pmCard.getId().intValue())))
+                .andExpect(jsonPath("$.status", is("SUCCESS")))
+                .andExpect(jsonPath("$.amount", is(5_000)))
+                .andExpect(jsonPath("$.currency", is("KRW")))
+                .andExpect(jsonPath("$.provider", is("toss")))
+                .andExpect(jsonPath("$.methodType", is("CARD")))
+                .andExpect(jsonPath("$.transactionId", is("payKey_abc123")))
+                .andExpect(jsonPath("$.createdAt", notNullValue()))
+                .andExpect(jsonPath("$.paidAt", notNullValue()))
+                .andExpect(jsonPath("$.idempotencyKey", is("idem-001")))
+                .andExpect(jsonPath("$.balanceAfter", notNullValue()));
+    }
+
+    // 2) 멱등: 같은 키로 두 번 쏘면 같은 결과
+    @Test
+    @WithMockUser(username = "pay@test.com")
+    void charge_idempotent_returns_same_result() throws Exception {
+        // 첫 호출 성공
+        given(tossBillingClientService.charge(eq(billingKey), eq(3_000L), anyString(), anyString()))
+                .willReturn(PgChargeResultResponse.builder()
+                        .success(true)
+                        .transactionId("payKey_idem")
+                        .build());
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(pmCard.getId());
+        req.setAmount(3_000L);
+        req.setIdempotencyKey("idem-dup");
+
+        // 1차 호출
+        mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("SUCCESS")))
+                .andExpect(jsonPath("$.transactionId", is("payKey_idem")));
+
+        // 2차 호출(같은 키) → PG 안 타고 기존 결과 그대로
+        mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("SUCCESS")))
+                .andExpect(jsonPath("$.transactionId", is("payKey_idem")));
+    }
+
+    // 3) 내 결제 목록 조회
+    @Test
+    @WithMockUser(username = "pay@test.com")
+    void get_my_payments_list() throws Exception {
+        // 하나 만들어두기
+        given(tossBillingClientService.charge(eq(billingKey), anyLong(), anyString(), anyString()))
+                .willReturn(PgChargeResultResponse.builder().success(true).transactionId("k1").build());
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(pmCard.getId());
+        req.setAmount(2_500L);
+        req.setIdempotencyKey("idem-list-1");
+
+        mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/payments/me")
+                        .param("page", "1")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page", is(1)))
+                .andExpect(jsonPath("$.size", is(20)))
+                .andExpect(jsonPath("$.total", greaterThanOrEqualTo(1)))
+                .andExpect(jsonPath("$.items[0].paymentId", notNullValue()))
+                .andExpect(jsonPath("$.items[0].amount", notNullValue()))
+                .andExpect(jsonPath("$.items[0].status", notNullValue()));
+    }
+
+    // 4) 내 결제 단건 상세
+    @Test
+    @WithMockUser(username = "pay@test.com")
+    void get_my_payment_detail() throws Exception {
+        // 하나 충전하고 그 id로 상세 조회
+        given(tossBillingClientService.charge(eq(billingKey), eq(4_000L), anyString(), anyString()))
+                .willReturn(PgChargeResultResponse.builder().success(true).transactionId("k2").build());
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(pmCard.getId());
+        req.setAmount(4_000L);
+        req.setIdempotencyKey("idem-detail");
+
+        // 생성 응답에서 paymentId 추출
+        String body = mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        // JsonPath로 꺼내도 되고, 간단히 Jackson으로 map 해도 됨
+        long paymentId = om.readTree(body).get("paymentId").asLong();
+
+        mockMvc.perform(get("/api/v1/payments/me/{paymentId}", paymentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paymentId", is((int) paymentId)))
+                .andExpect(jsonPath("$.amount", is(4_000)))
+                .andExpect(jsonPath("$.status", is("SUCCESS")))
+                .andExpect(jsonPath("$.transactionId", is("k2")))
+                .andExpect(jsonPath("$.paidAt", notNullValue()));
+    }
+
+    // 5) 토스 빌링키 발급 API
+    @Test
+    @WithMockUser(username = "pay@test.com")
+    void issue_billing_key_success() throws Exception {
+        given(tossBillingClientService.issueBillingKey(startsWith("user-"), eq("AUTH-123")))
+                .willReturn(TossIssueBillingKeyResponse.builder()
+                        .billingKey("BILL-XYZ")
+                        .provider("toss")
+                        .cardBrand("SHINHAN")
+                        .cardNumber("****-****-****-1234")
+                        .expMonth(12)
+                        .expYear(2030)
+                        .build());
+
+        String payload = """
+                {"authKey":"AUTH-123"}
+                """;
+
+        mockMvc.perform(post("/api/v1/payments/toss/issue-billing-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.billingKey", is("BILL-XYZ")))
+                .andExpect(jsonPath("$.provider", is("toss")))
+                .andExpect(jsonPath("$.cardBrand", is("SHINHAN")));
+    }
+
+    // 6) 인증 없으면 401
+    @Test
+    void charge_unauthorized_401() throws Exception {
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(999L);
+        req.setAmount(1000L);
+        req.setIdempotencyKey("idem-unauth");
+
+        mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/backend/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/backend/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,235 @@
+package com.backend.domain.payment.service;
+
+import com.backend.domain.cash.entity.Cash;
+import com.backend.domain.cash.repository.CashRepository;
+import com.backend.domain.cash.repository.CashTransactionRepository;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.payment.constant.PaymentMethodType;
+import com.backend.domain.payment.dto.MyPaymentResponse;
+import com.backend.domain.payment.dto.MyPaymentsResponse;
+import com.backend.domain.payment.dto.PgChargeResultResponse;
+import com.backend.domain.payment.dto.PaymentRequest;
+import com.backend.domain.payment.dto.PaymentResponse;
+import com.backend.domain.payment.entity.Payment;
+import com.backend.domain.payment.entity.PaymentMethod;
+import com.backend.domain.payment.repository.PaymentMethodRepository;
+import com.backend.domain.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@Transactional
+class PaymentServiceTest {
+
+    @Autowired PaymentService paymentService;
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired PaymentMethodRepository paymentMethodRepository;
+    @Autowired PaymentRepository paymentRepository;
+    @Autowired CashRepository cashRepository;
+    @Autowired CashTransactionRepository cashTransactionRepository;
+
+    @MockBean TossBillingClientService tossBillingClientService;
+
+    Member me;
+    PaymentMethod card;
+
+    @BeforeEach
+    void setUp() {
+        // 회원 (password는 NOT NULL 이므로 꼭 채움)
+        me = memberRepository.save(
+                Member.builder()
+                        .email("pay@test.com")
+                        .password("pw!")
+                        .nickname("payer")
+                        .build()
+        );
+
+        // 기본 카드 수단 (토큰=billingKey 필수)
+        card = paymentMethodRepository.save(
+                PaymentMethod.builder()
+                        .member(me)
+                        .type(PaymentMethodType.CARD)
+                        .token("BILL-001")          // billingKey
+                        .alias("테스트카드")
+                        .isDefault(true)
+                        .brand("SHINHAN")
+                        .last4("1234")
+                        .expMonth(12)
+                        .expYear(2030)
+                        .provider("toss")
+                        .active(true)
+                        .deleted(false)
+                        .build()
+        );
+    }
+
+    @Test
+    void charge_success_지갑입금_원장생성() {
+        // given: 토스 빌링 성공 응답
+        given(tossBillingClientService.charge(
+                ArgumentMatchers.eq("BILL-001"),
+                ArgumentMatchers.eq(5_000L),
+                ArgumentMatchers.eq("idem-1"),
+                ArgumentMatchers.eq("user-" + me.getId())
+        )).willReturn(PgChargeResultResponse.builder()
+                .success(true)
+                .transactionId("PAY-123")
+                .build());
+
+        // when
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(card.getId());
+        req.setAmount(5_000L);
+        req.setIdempotencyKey("idem-1");
+
+        PaymentResponse res = paymentService.charge(me, req);
+
+        // then: 응답/영수증
+        assertThat(res.getStatus()).isEqualTo("SUCCESS");
+        assertThat(res.getAmount()).isEqualTo(5_000L);
+        assertThat(res.getTransactionId()).isEqualTo("PAY-123");
+        assertThat(res.getCashTransactionId()).isNotNull();
+        assertThat(res.getBalanceAfter()).isEqualTo(5_000L); // 새 지갑(0원) 생성 후 입금
+
+        // DB 상태 확인
+        Payment p = paymentRepository.findById(res.getPaymentId()).orElseThrow();
+        assertThat(p.getPaidAt()).isNotNull();
+
+        Cash cash = cashRepository.findByMember(me).orElseThrow();
+        assertThat(cash.getBalance()).isEqualTo(5_000L);
+    }
+
+    @Test
+    void charge_idempotent_같은키면_PG호출없이_이전영수증반환() {
+        // 1차 호출 mock
+        given(tossBillingClientService.charge(
+                ArgumentMatchers.eq("BILL-001"),
+                ArgumentMatchers.eq(3_000L),
+                ArgumentMatchers.eq("idem-x"),
+                ArgumentMatchers.eq("user-" + me.getId())
+        )).willReturn(PgChargeResultResponse.builder()
+                .success(true)
+                .transactionId("PAY-AAA")
+                .build());
+
+        // 첫 호출
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(card.getId());
+        req.setAmount(3_000L);
+        req.setIdempotencyKey("idem-x");
+        PaymentResponse first = paymentService.charge(me, req);
+
+        // 두 번째 호출(같은 멱등키) — tossBillingClientService 가 불리면 안 됨
+        PaymentResponse second = paymentService.charge(me, req);
+
+        assertThat(second.getPaymentId()).isEqualTo(first.getPaymentId());
+        assertThat(second.getTransactionId()).isEqualTo("PAY-AAA");
+        assertThat(second.getAmount()).isEqualTo(3_000L);
+
+        // PG는 정확히 1번만 호출됨
+        verify(tossBillingClientService, times(1))
+                .charge("BILL-001", 3_000L, "idem-x", "user-" + me.getId());
+    }
+
+    @Test
+    void charge_fail_빌링키없으면_400() {
+        // 빌링키 없는 수단
+        PaymentMethod noBillingKey = paymentMethodRepository.save(
+                PaymentMethod.builder()
+                        .member(me)
+                        .type(PaymentMethodType.CARD)
+                        .token(null) // ★ 없음
+                        .alias("무효카드")
+                        .isDefault(false)
+                        .brand("KB")
+                        .last4("5555")
+                        .expMonth(1)
+                        .expYear(2031)
+                        .provider("toss")
+                        .active(true)
+                        .deleted(false)
+                        .build()
+        );
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(noBillingKey.getId());
+        req.setAmount(1_000L);
+        req.setIdempotencyKey("idem-bad");
+
+        assertThatThrownBy(() -> paymentService.charge(me, req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("billingKey가 없습니다");
+    }
+
+    @Test
+    void getMyPayments_조회_및_getMyPaymentDetail_조회() {
+        // 먼저 하나 성공 결제 만들어두기
+        given(tossBillingClientService.charge(
+                ArgumentMatchers.eq("BILL-001"),
+                ArgumentMatchers.eq(7_000L),
+                ArgumentMatchers.eq("idem-list"),
+                ArgumentMatchers.eq("user-" + me.getId())
+        )).willReturn(PgChargeResultResponse.builder()
+                .success(true)
+                .transactionId("PAY-LIST")
+                .build());
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(card.getId());
+        req.setAmount(7_000L);
+        req.setIdempotencyKey("idem-list");
+        PaymentResponse payRes = paymentService.charge(me, req);
+
+        // 목록 조회
+        MyPaymentsResponse list = paymentService.getMyPayments(me, 1, 10);
+        assertThat(list.getTotal()).isGreaterThanOrEqualTo(1);
+        assertThat(list.getItems()).isNotEmpty();
+        assertThat(list.getItems().get(0).getPaymentId()).isEqualTo(payRes.getPaymentId());
+
+        // 단건 상세
+        MyPaymentResponse detail = paymentService.getMyPaymentDetail(me, payRes.getPaymentId());
+        assertThat(detail.getPaymentId()).isEqualTo(payRes.getPaymentId());
+        assertThat(detail.getAmount()).isEqualTo(7_000L);
+        assertThat(detail.getTransactionId()).isEqualTo("PAY-LIST");
+        assertThat(detail.getPaidAt()).isNotNull();
+    }
+
+    @Test
+    void charge_fail_PG_4xx면_Service도_그대로_전파() {
+        // PG 4xx 흉내
+        given(tossBillingClientService.charge(
+                ArgumentMatchers.eq("BILL-001"),
+                ArgumentMatchers.eq(50_000L),
+                ArgumentMatchers.eq("idem-4xx"),
+                ArgumentMatchers.eq("user-" + me.getId())
+        )).willThrow(new ResponseStatusException(org.springframework.http.HttpStatus.BAD_REQUEST, "Toss 4xx"));
+
+        PaymentRequest req = new PaymentRequest();
+        req.setPaymentMethodId(card.getId());
+        req.setAmount(50_000L);
+        req.setIdempotencyKey("idem-4xx");
+
+        assertThatThrownBy(() -> paymentService.charge(me, req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Toss 4xx");
+
+        // 실패로 마킹 되었는지(최초 PENDING은 저장됨)
+        assertThat(paymentRepository.findAll())
+                .anySatisfy(p -> assertThat(p.getStatus().name()).isIn("FAILED", "PENDING"));
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 낙찰 결제(출금)
  - 낙찰자 지갑 출금(WITHDRAW) + Bid에 paidAt/paidAmount 기록..
  - 멱등 처리(이미 결제된 입찰은 재차 출금하지 않음)..
  - 권한/상태 검사(낙찰 상태에서만 결제)..
 
## 테스트
- PaymentService 단위/통합 테스트: 성공/멱등/PG 4xx/5xx/유효성 등..
- Bid 낙찰 결제 서비스/컨트롤러 테스트: 정상/중복/상태오류/권한오류..
- CashService 출금 테스트: 정상/잔액부족..

## 다음에 할 것
- 경매 종료 스케줄러: BIDDING → SUCCESSFUL/FAILED 자동 전환 및 최고가 확정..