### PR TITLE
[Feat]: 인증 예외 핸들링 구현

### DIFF
--- a/src/main/java/com/backend/domain/home/controller/HomeController.java
+++ b/src/main/java/com/backend/domain/home/controller/HomeController.java
@@ -1,6 +1,5 @@
 package com.backend.domain.home.controller;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/backend/domain/product/controller/ApiV1ProductController.java
+++ b/src/main/java/com/backend/domain/product/controller/ApiV1ProductController.java
@@ -13,9 +13,9 @@ import com.backend.domain.product.entity.Product;
 import com.backend.domain.product.enums.AuctionStatus;
 import com.backend.domain.product.enums.ProductSearchSortType;
 import com.backend.domain.product.enums.SaleStatus;
+import com.backend.domain.product.exception.ProductException;
 import com.backend.domain.product.mapper.ProductMapper;
 import com.backend.domain.product.service.ProductService;
-import com.backend.global.exception.ServiceException;
 import com.backend.global.page.dto.PageDto;
 import com.backend.global.response.RsData;
 import jakarta.validation.Valid;
@@ -140,7 +140,7 @@ public class ApiV1ProductController implements ApiV1ProductControllerDocs {
             @RequestParam(defaultValue = "SELLING") SaleStatus status,
             @RequestParam(defaultValue = "LATEST") ProductSearchSortType sort
     ) {
-        Member actor = memberService.findById(memberId).orElseThrow(() -> new ServiceException("404", "존재하지 않는 회원입니다"));
+        Member actor = memberService.findById(memberId).orElseThrow(ProductException::memberNotFound);
 
         Page<Product> products = productService.findByMemberPaged(page, size, sort, actor, status);
 

--- a/src/main/java/com/backend/domain/product/exception/ProductException.java
+++ b/src/main/java/com/backend/domain/product/exception/ProductException.java
@@ -23,6 +23,11 @@ public class ProductException extends ServiceException {
         return notFound(2, "존재하지 않는 이미지입니다");
     }
 
+    // 일단 ProductException 에서 정의 (MemberException 생성되면 제거)
+    public static ProductException memberNotFound() {
+        return new ProductException(RsStatus.NOT_FOUND.getResultCode(), "존재하지 않는 회원입니다");
+    }
+
     // ======================================= forbidden ======================================= //
     private static ProductException forbidden(int detailCode, String msg) {
         return new ProductException(RsStatus.FORBIDDEN.getResultCode() + "-" + detailCode, msg);

--- a/src/main/java/com/backend/global/initdata/BaseInitData.java
+++ b/src/main/java/com/backend/global/initdata/BaseInitData.java
@@ -4,7 +4,6 @@ import com.backend.domain.bid.entity.Bid;
 import com.backend.domain.bid.repository.BidRepository;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.repository.MemberRepository;
-import com.backend.domain.member.service.MemberService;
 import com.backend.domain.product.entity.Product;
 import com.backend.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/backend/global/security/SecurityConfig.java
+++ b/src/main/java/com/backend/global/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.backend.global.security;
 
+import com.backend.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +27,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -54,7 +57,19 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable);
+                .logout(AbstractHttpConfigurer::disable)
+                .exceptionHandling(
+                        exception -> exception
+                                .authenticationEntryPoint((request, response, authException) -> {
+                                    response.setContentType("application/json;charset=UTF-8");
+                                    response.setStatus(401);
+                                    response.getWriter().write(
+                                            objectMapper.writeValueAsString(
+                                                    ServiceException.unauthorized("로그인 후 이용해주세요.")
+                                            )
+                                    );
+                                })
+                );
         return http.build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 100 # N+1 문제 해결
+    open-in-view: false
 
   data:
     redis:

--- a/src/test/java/com/backend/domain/member/controller/ApiV1MemberControllerTest.java
+++ b/src/test/java/com/backend/domain/member/controller/ApiV1MemberControllerTest.java
@@ -8,11 +8,6 @@ import com.backend.domain.product.service.FileService;
 import com.backend.global.redis.TestRedisConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Import;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,24 +15,25 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import java.nio.charset.StandardCharsets;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(properties = {
         "cloud.aws.credentials.access-key=",
@@ -253,7 +249,7 @@ class ApiV1MemberControllerTest {
                 .andDo(print());
 
         // Then (접근 거부 확인)
-        accessResult.andExpect(status().isForbidden());
+        accessResult.andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/com/backend/domain/product/controller/ApiV1ProductControllerTest.java
+++ b/src/test/java/com/backend/domain/product/controller/ApiV1ProductControllerTest.java
@@ -1004,6 +1004,25 @@ class ApiV1ProductControllerTest {
         }
     }
 
+    @Test
+    @DisplayName("특정 회원 상품 목록 조회 - 실패")
+    @Transactional
+    void getProductsByMemberFailed() throws Exception {
+        // when
+        long memberId = 9999L;
+        ResultActions resultActions = mvc
+                .perform(get("/api/v1/products/members/" + memberId))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ApiV1ProductController.class))
+                .andExpect(handler().methodName("getProductsByMember"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 회원입니다"));
+    }
+
     // ======================================= Helper methods ======================================= //
     private ProductCreateRequest createValidRequest() {
         return new ProductCreateRequest(


### PR DESCRIPTION
- 인증 예외 핸들링 구현했습니다
  - 인증 실패 시 401로 "로그인 후 이용해주세요" 라고 갑니다
- 중간결과물 피드백에 있었던 OSIV 껐습니다
- 존재하지 않는 회원 예외를 일단 ProductException에 추가했습니다. 후에 MemberException이 만들어진다면 이동 후 제거하겠습니다