### PR TITLE
[Feat]: Toss 빌링(카드 등록) 연동 + 쿠키 기반 인증 + 멱등키 발급

### DIFF
--- a/src/main/java/com/backend/domain/payment/controller/ApiV1PaymentController.java
+++ b/src/main/java/com/backend/domain/payment/controller/ApiV1PaymentController.java
@@ -4,10 +4,7 @@ import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.service.MemberService;
 import com.backend.domain.payment.dto.request.PaymentRequest;
 import com.backend.domain.payment.dto.request.TossIssueBillingKeyRequest;
-import com.backend.domain.payment.dto.response.MyPaymentResponse;
-import com.backend.domain.payment.dto.response.MyPaymentsResponse;
-import com.backend.domain.payment.dto.response.PaymentResponse;
-import com.backend.domain.payment.dto.response.TossIssueBillingKeyResponse;
+import com.backend.domain.payment.dto.response.*;
 import com.backend.domain.payment.service.PaymentService;
 import com.backend.domain.payment.service.TossBillingClientService;
 import com.backend.global.response.RsData;
@@ -18,20 +15,29 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/payments")
 @Tag(name = "Payments", description = "지갑 충전 API")
 public class ApiV1PaymentController {
+
+    @Value("${pg.toss.clientKey}")
+    private String tossClientKey;
 
     private final MemberService memberService;
     private final PaymentService paymentService;
@@ -44,7 +50,7 @@ public class ApiV1PaymentController {
     }
 
     @PostMapping
-    @Operation(summary="지갑 충전 요청", description="idempotencyKey로 중복 충전 방지, 일단은 idempotencyKey 아무키로 등록해주세요!")
+    @Operation(summary="지갑 충전 요청", description="idempotencyKey로 중복 충전 방지")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "충전 완료",
                     content = @Content(schema = @Schema(implementation = RsData.class))),
@@ -85,6 +91,41 @@ public class ApiV1PaymentController {
         TossIssueBillingKeyResponse data = tossBillingClientService.issueBillingKey(customerKey, req.getAuthKey());
 
         return RsData.ok("빌링키가 발급되었습니다.", data);
+    }
+    @GetMapping("/toss/billing-auth-params")
+    @Operation(
+            summary = "토스 카드등록(빌링) 팝업 파라미터 조회",
+            description = """
+            토스 카드 등록 창을 띄우기 위해 FE가 먼저 호출하는 엔드포인트입니다.
+            - 로그인(인증) 필요: 서버가 로그인 사용자의 customerKey(`user-{id}`)를 만들어 줍니다.
+            - 응답 값:
+              * clientKey   : Toss Payments 공개 키 (FE에서 Toss SDK 초기화에 사용)
+              * customerKey : 사용자 고유키 (카드 등록/결제 시 동일 값 사용)
+              * successUrl  : 카드 등록 성공 후 리다이렉트될 페이지
+              * failUrl     : 카드 등록 실패 시 리다이렉트될 페이지
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = RsData.class)))
+    })
+    public RsData<TossBillingAuthParamsResponse> getBillingAuthParams(
+            @AuthenticationPrincipal User user, HttpServletRequest req) {
+
+        Member me = memberService.findMemberByEmail(user.getUsername());
+        String customerKey = "user-" + me.getId();
+
+        // origin 계산(예: http://localhost:8080)
+        String origin = req.getScheme() + "://" + req.getServerName()
+                + ((req.getServerPort()==80 || req.getServerPort()==443) ? "" : ":" + req.getServerPort());
+
+        TossBillingAuthParamsResponse data = new TossBillingAuthParamsResponse(
+                tossClientKey,
+                customerKey,
+                origin + "/payments/toss/billing-success.html",
+                origin + "/payments/toss/billing-fail.html"
+        );
+        return RsData.ok("ok", data);
     }
 
     @GetMapping("/me")
@@ -130,6 +171,20 @@ public class ApiV1PaymentController {
         MyPaymentResponse data = paymentService.getMyPaymentDetail(actor, paymentId);
 
         return RsData.ok("결제 상세가 조회되었습니다.", data);
+    }
+
+    @GetMapping("/idempotency-key")
+    @Operation(
+            summary = "멱등키(결제 재시도 식별 키) 발급",
+            description = "결제 요청 전에 1회 호출해서 받은 키를 재시도 시에도 동일하게 사용하세요."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "발급 성공",
+                    content = @Content(schema = @Schema(implementation = RsData.class)))
+    })
+    public RsData<IdempotencyKeyResponse> newIdempotencyKey() {
+        String key = UUID.randomUUID().toString();
+        return RsData.ok("멱등키가 발급되었습니다.", new IdempotencyKeyResponse(key));
     }
 
 }

--- a/src/main/java/com/backend/domain/payment/dto/request/PaymentRequest.java
+++ b/src/main/java/com/backend/domain/payment/dto/request/PaymentRequest.java
@@ -1,5 +1,6 @@
 package com.backend.domain.payment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,6 +19,10 @@ public class PaymentRequest {
     @Min(100)
     private Long amount;           // 충전 금액(원)..
 
-    @NotBlank
+    @Schema(
+            description = "멱등키(재시도 시 동일하게 사용)",
+            example = "d6a6f3ad-5d9a-4a3a-b0a5-7e0a2b77c2b1",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String idempotencyKey; // 멱등키(재시도 동일키)..
 }

--- a/src/main/java/com/backend/domain/payment/dto/request/TossIssueBillingKeyRequest.java
+++ b/src/main/java/com/backend/domain/payment/dto/request/TossIssueBillingKeyRequest.java
@@ -1,11 +1,12 @@
 package com.backend.domain.payment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class TossIssueBillingKeyRequest {
-    private String customerKey;
+    @Schema(description = "Toss가 successUrl로 전달한 키", example = "bln_xxx")
     private String authKey;
 }

--- a/src/main/java/com/backend/domain/payment/dto/response/IdempotencyKeyResponse.java
+++ b/src/main/java/com/backend/domain/payment/dto/response/IdempotencyKeyResponse.java
@@ -1,0 +1,5 @@
+package com.backend.domain.payment.dto.response;
+
+public record IdempotencyKeyResponse(
+        String idempotencyKey
+) {}

--- a/src/main/java/com/backend/domain/payment/dto/response/TossBillingAuthParamsResponse.java
+++ b/src/main/java/com/backend/domain/payment/dto/response/TossBillingAuthParamsResponse.java
@@ -1,0 +1,8 @@
+package com.backend.domain.payment.dto.response;
+
+public record TossBillingAuthParamsResponse(
+        String clientKey,
+        String customerKey,
+        String successUrl,
+        String failUrl
+) {}

--- a/src/main/java/com/backend/domain/payment/dto/response/TossIssueBillingKeyResponse.java
+++ b/src/main/java/com/backend/domain/payment/dto/response/TossIssueBillingKeyResponse.java
@@ -1,15 +1,26 @@
 package com.backend.domain.payment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class TossIssueBillingKeyResponse {
+    @Schema(description = "Toss 토큰(우리 쪽 저장용)", example = "PAhFKE3...")
     private String billingKey;
+
     private String provider;   // "toss"
+
+    @Schema(description = "카드 브랜드/발급사", example = "SHINHAN")
     private String cardBrand;  // 선택: 스냅샷에 쓰려면
-    private String cardNumber; // 선택
+
+    @Schema(description = "카드 끝 4자리", example = "1234")
+    private String last4; // 선택
+
+    @Schema(description = "만료월", example = "12")
     private Integer expMonth;  // 선택
+
+    @Schema(description = "만료년", example = "2028")
     private Integer expYear;   // 선택
 }

--- a/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.*;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -50,8 +51,10 @@ public class PaymentService {
         if (req.getAmount() > MAX_AMOUNT_PER_TX)
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"1회 최대 충전 한도를 초과했습니다.");
 
-        if (req.getIdempotencyKey() == null || req.getIdempotencyKey().isBlank())
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "idempotencyKey가 필요합니다.");
+        if (req.getIdempotencyKey() == null || req.getIdempotencyKey().isBlank()){
+            req.setIdempotencyKey(UUID.randomUUID().toString());
+            log.info("[IDEMP] generated new idempotencyKey={}", req.getIdempotencyKey());
+        }
 
         // 멱등 선조회(같은 회원+키면 기존 결과 그대로 반환)..
         var existingOpt = paymentRepository.findByMemberAndIdempotencyKey(actor, req.getIdempotencyKey());

--- a/src/main/java/com/backend/domain/payment/service/TossBillingClientService.java
+++ b/src/main/java/com/backend/domain/payment/service/TossBillingClientService.java
@@ -90,7 +90,7 @@ public class TossBillingClientService {
             return TossIssueBillingKeyResponse.builder()
                     .billingKey(billingKey)
                     .cardBrand(cardBrand)
-                    .cardNumber(cardNumber)
+                    .last4(cardNumber)
                     .expMonth(expMonth)
                     .expYear(expYear)
                     .build();

--- a/src/main/resources/static/billing.html
+++ b/src/main/resources/static/billing.html
@@ -3,36 +3,21 @@
 <title>Toss Billing Auth</title>
 <script src="https://js.tosspayments.com/v1"></script>
 
-<label>API Base</label>
-<input id="base" value="http://localhost:8080/api/v1" style="width:420px"><br>
-<label>Bearer Token</label>
-<input id="token" style="width:420px"><br>
-<button id="btn">빌링키 발급(카드 등록)</button>
+<button id="pay">결제하기</button>
 
 <script>
-    const clientKey = 'test_ck_Z1aOwX7K8myXN7zQk1dP8yQxzvNP'; // ← 토스 clientKey(테스트)
-    const toss = TossPayments(clientKey);
+    document.getElementById('pay').onclick = async () => {
+      // ★ 로그인 후 쿠키로 인증되므로 credentials: 'include'
+      const r = await fetch('/api/v1/payments/toss/billing-auth-params', { credentials: 'include' });
+      if (!r.ok) { alert('인증 필요'); return; }
+      const body = await r.json();
+      const p = body.data || body;
 
-   async function getMyId(base, token) {
-      const resp = await fetch(base + '/members/me', {
-        headers: { Authorization: 'Bearer ' + token }
-      }).then(r => r.json());
-      // RsData 포맷 방어
-      const me = resp?.data ?? resp;
-      return me?.id;
-      }
-
-
-  document.getElementById('btn').onclick = async () => {
-    const base  = document.getElementById('base').value.trim();
-    const token = document.getElementById('token').value.trim();
-
-    const memberId    = await getMyId(base, token);
-    const customerKey = `user-${memberId}`;      // ★ 서버와 동일 규칙
-
-    const successUrl = location.origin + '/payments/toss/billing-success.html';
-    const failUrl    = location.origin + '/payments/toss/billing-fail.html';
-
-    toss.requestBillingAuth('카드', { customerKey, successUrl, failUrl });
-  };
+      const toss = TossPayments(p.clientKey);
+      toss.requestBillingAuth('카드', {
+        customerKey: p.customerKey,   // 서버가 계산해 준 값
+        successUrl:  p.successUrl,    // 예: http://localhost:8080/payments/toss/billing-success.html
+        failUrl:     p.failUrl
+      });
+    };
 </script>

--- a/src/main/resources/static/payments/toss/billing-success.html
+++ b/src/main/resources/static/payments/toss/billing-success.html
@@ -1,101 +1,79 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>빌링 성공</title>
-<h2>빌링키 발급 완료 처리</h2>
+<title>빌링키 발급 완료</title>
+<h2>빌링키 발급 완료</h2>
 
-<label>API Base</label>
-<input id="base" value="http://localhost:8080/api/v1" style="width:420px"><br>
-<label>Bearer Token</label>
-<input id="token" style="width:420px"><br>
-<button id="btn">서버에 최종 발급 요청 → 결제수단 저장</button>
-<pre id="out"></pre>
+<label>별명(alias): <input id="alias" value="내 카드"></label>
+<label style="margin-left:12px">
+    <input type="checkbox" id="isDefault" checked> 기본 결제수단으로 설정
+</label>
+<pre id="out" style="background:#111;color:#c8f;padding:12px;border-radius:8px;white-space:pre-wrap"></pre>
+<button id="goWallet" style="display:none">지갑 충전하러 가기</button>
 
 <script>
-    const p = new URLSearchParams(location.search);
-    const customerKey = p.get('customerKey');
-    const authKey     = p.get('authKey');
+    const log = (msg) =>
+      (document.getElementById('out').textContent += msg + '\n');
 
-    const $out = document.getElementById('out');
-    const print = (obj) => $out.textContent = JSON.stringify(obj, null, 2);
-
-    async function postJson(url, body, token) {
-      const r = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer ' + token
-        },
-        body: JSON.stringify(body)
-      });
-      const text = await r.text();               // ← 항상 text로 받아둠
-      if (!r.ok) throw new Error(`HTTP ${r.status}: ${text}`);
-      return text ? JSON.parse(text) : {};
-    }
-
-    function unwrap(resp) {
-      // 서버가 {resultCode, data} 형태로 줄 수도 있으니 방어
-      if (resp && typeof resp === 'object' && 'data' in resp && resp.data) return resp.data;
-      return resp;
-    }
-
-    function digitsLast4(s) {
-      if (!s) return null;
-      const only = String(s).replace(/\D/g, ''); // 숫자만
-      return only.length >= 4 ? only.slice(-4) : null;
-    }
-
-    document.getElementById('btn').onclick = async () => {
-      const base  = document.getElementById('base').value.trim();
-      const token = document.getElementById('token').value.trim();
-
-      const btn = document.getElementById('btn');
-      btn.disabled = true;
+    (async () => {
+      const qs = new URLSearchParams(location.search);
+      const authKey = qs.get('authKey'); // Toss가 successUrl로 넘겨준 값
+      if (!authKey) { log('authKey가 없습니다. 직접 접근하신 것 같아요.'); return; }
 
       try {
-        // 1) authKey -> billingKey 교환
-        let issue = await postJson(base + '/payments/toss/issue-billing-key',
-          { customerKey, authKey }, token);
-        issue = unwrap(issue);                   // 필요시 data 해제
-        print({ step: 'issue', issue });
+        log('1) 서버에 authKey 교환 요청 중...');
+        // 1) authKey -> billingKey 교환 (쿠키 인증)
+        const r1 = await fetch('/api/v1/payments/toss/issue-billing-key', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ authKey })
+        });
+        const res1 = await r1.json();
+        if (!r1.ok) throw new Error(`교환 실패: ${r1.status} ${res1.msg || ''}`);
 
-        if (!issue || !issue.billingKey) {
-          print({ step: 'issue-failed', issue });
-          btn.disabled = false;
-          return;
-        }
+        const d = res1.data || res1; // RsData 대응
+        const billingKey = d.billingKey;
+        log(`✓ 교환 성공 → billingKey=${billingKey}`);
 
-        // 2) 결제수단 저장에 필요한 필드 구성
-        const last4   = digitsLast4(issue.cardNumber) || '1111';
-        const expMonth = issue.expMonth ?? issue.expiryMonth ?? issue.expireMonth ?? null;
-        const expYear  = issue.expYear  ?? issue.expiryYear  ?? issue.expireYear  ?? null;
+        // 카드 정보(있으면) 보조로 사용
+        const brand   = d.cardBrand ?? null;
+        const last4   = d.cardNumber ? String(d.cardNumber).slice(-4) : null;
+        const expMon  = d.expMonth ?? null;
+        const expYear = d.expYear  ?? null;
 
-        // 디버그 출력(서버 400날 때 참고)
-        print({ step: 'before-save', payload: {
-          type: 'CARD', provider: 'toss', token: issue.billingKey,
-          alias: '메인카드', isDefault: true,
-          brand: issue.cardBrand || 'TEST',
-          last4, expMonth, expYear
-        }, rawIssue: issue });
+        // 2) 결제수단 저장 (서버 DTO에 맞춰 token/brand/provide 사용)
+        log('2) 결제수단 저장 중...');
+        const alias = document.getElementById('alias').value || '내 카드';
+        const isDefault = document.getElementById('isDefault').checked;
 
-        // 3) 결제수단 저장
-        let saved = await postJson(base + '/paymentMethods', {
-          type: 'CARD',
-          provider: 'toss',
-          token: issue.billingKey,
-          alias: '메인카드',
-          isDefault: true,
-          brand: issue.cardBrand || 'TEST',
-          last4,
-          expMonth,
-          expYear
-        }, token);
-        saved = unwrap(saved);
+        const r2 = await fetch('/api/v1/paymentMethods', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            provider: 'toss',        // ★ 서버가 기대하는 값
+            type: 'CARD',
+            alias: alias,
+            isDefault: isDefault,
+            token: billingKey,       // ★ billingKey를 token으로 저장
+            brand: brand,            // ★ cardBrand → brand
+            last4: last4,
+            expMonth: expMon,
+            expYear: expYear
+          })
+        });
+        const res2 = await r2.json();
+        if (!r2.ok) throw new Error(`저장 실패: ${r2.status} ${res2.msg || ''}`);
 
-        print({ step: 'done', issue, saved });
+        log('✓ 결제수단 저장 완료');
+
+        // 다음 화면 이동 버튼 노출(원하는 곳으로 이동)
+        const btn = document.getElementById('goWallet');
+        btn.style.display = 'inline-block';
+        btn.onclick = () => location.href = '/swagger-ui/index.html#/Payments/charge';
       } catch (e) {
-        print({ error: String(e) });
-      } finally {
-        btn.disabled = false;
+        log('에러: ' + e.message);
+        console.error(e);
       }
-    };
+    })();
 </script>


### PR DESCRIPTION
- GET /api/v1/payments/toss/billing-auth-params 추가
  - TossBillingAuthParamsResponse 반환(clientKey, customerKey, success/fail URL)
- POST /api/v1/payments/toss/issue-billing-key
  - Toss API와 연동해 authKey → billingKey 교환 (WebClient)
- GET /api/v1/payments/idempotency-key 추가
  - IdempotencyKeyResponse 반환(중복 결제 방지 키)
- 결제 로직에 billingKey 사용하도록 변경(/billing/{billingKey} 결제 요청)
- 결제수단 등록 시 billingKey/카드 스냅샷(brand, last4, expMonth, expYear) 저장

- auth
  - JwtAuthenticationFilter가 Authorization 헤더 또는 쿠키에서 토큰 조회하도록 개선