### PR TITLE
[Feat]: 오프라인 알림 및 정합성 검사 수정

### DIFF
--- a/src/main/java/com/backend/domain/bid/dto/BidMessageDto.java
+++ b/src/main/java/com/backend/domain/bid/dto/BidMessageDto.java
@@ -1,0 +1,14 @@
+package com.backend.domain.bid.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BidMessageDto {
+    private Long productId;
+    private Long bidderId;
+    private Long price;
+}

--- a/src/main/java/com/backend/domain/bid/service/BidConsumerService.java
+++ b/src/main/java/com/backend/domain/bid/service/BidConsumerService.java
@@ -1,0 +1,202 @@
+package com.backend.domain.bid.service;
+
+import com.backend.domain.bid.dto.BidMessageDto;
+import com.backend.domain.bid.dto.BidResponseDto;
+import com.backend.domain.bid.entity.Bid;
+import com.backend.domain.bid.enums.BidStatus;
+import com.backend.domain.bid.repository.BidRepository;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.notification.service.BidNotificationService;
+import com.backend.domain.product.entity.Product;
+import com.backend.domain.product.enums.AuctionStatus;
+import com.backend.domain.product.event.helper.ProductChangeTracker;
+import com.backend.domain.product.repository.jpa.ProductRepository;
+import com.backend.global.exception.ServiceException;
+import com.backend.global.lock.DistributedLock;
+import com.backend.global.websocket.service.WebSocketService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BidConsumerService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final BidRepository bidRepository;
+    private final WebSocketService webSocketService;
+    private final BidNotificationService bidNotificationService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Scheduled(fixedDelay = 100) // 0.1초마다 실행
+    public void consumeBidQueue() {
+        String messageJson = redisTemplate.opsForList().leftPop("bid_queue");
+
+        if (messageJson != null) {
+            try {
+                BidMessageDto messageDto = objectMapper.readValue(messageJson, BidMessageDto.class);
+                processBid(messageDto);
+            } catch (JsonProcessingException e) {
+                log.error("입찰 메시지 역직렬화 실패: {}", messageJson, e);
+            } catch (Exception e) {
+                log.error("입찰 처리 중 예외 발생: {}", e.getMessage(), e);
+                // 예외 발생 시, 해당 메시지를 별도의 Dead Letter Queue로 보내거나 로깅 후 폐기하는 정책 필요
+            }
+        }
+    }
+
+    @DistributedLock(key = "'product:' + #messageDto.productId", waitTime = 10, leaseTime = 10)
+    public void processBid(BidMessageDto messageDto) {
+        Long productId = messageDto.getProductId();
+        Long bidderId = messageDto.getBidderId();
+        Long price = messageDto.getPrice();
+
+        // Product/Member 조회
+        Product product = productRepository.findByIdWithBids(productId)
+                .orElseThrow(() -> ServiceException.notFound("존재하지 않는 상품입니다."));
+        Member member = memberRepository.findById(bidderId)
+                .orElseThrow(() -> ServiceException.notFound("존재하지 않는 사용자입니다."));
+
+        // 유효성 검증
+        validateBid(product, member, price);
+
+        Long previousHighestPrice = bidRepository.findHighestBidPrice(productId).orElse(null);
+
+        // 이전 최고 입찰자 확인 (입찰 밀림 알림용)
+        Bid previousHighestBid = null;
+        if (previousHighestPrice != null) {
+            List<Bid> recentBids = bidRepository.findNBids(productId, 10);
+            previousHighestBid = recentBids.stream()
+                    .filter(bid -> bid.getBidPrice().equals(previousHighestPrice))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        // 입찰 생성 및 저장
+        Bid savedBid = saveBid(product, member, price);
+
+        // 상품 업데이트
+        updateProduct(product, savedBid, price);
+
+        // 응답 생성
+        BidResponseDto bidResponse = createBidResponse(savedBid);
+
+        // 실시간 브로드캐스트
+        webSocketService.broadcastBidUpdate(productId, bidResponse);
+
+        // 입찰 성공 알림 (현재 입찰자에게)
+        bidNotificationService.notifyBidSuccess(bidderId, product, price);
+
+        // 입찰 밀림 알림 (이전 최고 입찰자에게)
+        if (previousHighestBid != null && !previousHighestBid.getMember().getId().equals(bidderId)) {
+            bidNotificationService.notifyBidOutbid(
+                    previousHighestBid.getMember().getId(),
+                    product,
+                    previousHighestBid.getBidPrice(),
+                    price
+            );
+        }
+        log.info("입찰 성공: 상품 ID {}, 입찰자 ID {}, 입찰가 {}", productId, bidderId, price);
+    }
+
+    private Bid saveBid(Product product, Member member, Long bidPrice) {
+        Bid bid = Bid.builder()
+                .bidPrice(bidPrice)
+                .status(BidStatus.BIDDING)
+                .product(product)
+                .member(member)
+                .build();
+        return bidRepository.save(bid);
+    }
+
+    private void validateBid(Product product, Member member, Long bidPrice) {
+        // 경매 상태 확인
+        validateAuctionStatus(product);
+
+        // 경매 시간 확인
+        validateAuctionTime(product);
+
+        // 본인 상품 입찰 방지
+        validateNotSelfBid(product, member);
+
+        // 입찰 금액 유효성 검증
+        validateBidPrice(bidPrice, product);
+    }
+
+    private void validateAuctionStatus(Product product) {
+        if (!AuctionStatus.BIDDING.getDisplayName().equals(product.getStatus())) {
+            throw ServiceException.badRequest("현재 입찰할 수 없는 상품입니다.");
+        }
+    }
+
+    private void validateAuctionTime(Product product) {
+        LocalDateTime now = LocalDateTime.now();
+        if (product.getStartTime() != null && now.isBefore(product.getStartTime())) {
+            throw ServiceException.badRequest("경매가 아직 시작되지 않았습니다.");
+        }
+        if (product.getEndTime() != null && now.isAfter(product.getEndTime())) {
+            throw ServiceException.badRequest("경매가 이미 종료되었습니다.");
+        }
+    }
+
+    private void validateNotSelfBid(Product product, Member member) {
+        Member seller = product.getSeller();
+        if (seller != null && seller.getId().equals(member.getId())) {
+            throw ServiceException.badRequest("본인이 등록한 상품에는 입찰할 수 없습니다.");
+        }
+    }
+
+    private void validateBidPrice(Long bidPrice, Product product) {
+        // 입찰 금액 기본 검증
+        if (bidPrice == null || bidPrice <= 0) {
+            throw ServiceException.badRequest("입찰 금액은 0보다 커야 합니다.");
+        }
+
+        // 현재 최고가보다 높은지 확인
+        Long currentHighestPrice = bidRepository.findHighestBidPrice(product.getId()).orElse(product.getInitialPrice());
+        if (bidPrice <= currentHighestPrice) {
+            throw ServiceException.badRequest("입찰 금액이 현재 최고가인 " + currentHighestPrice + "원 보다 높아야 합니다.");
+        }
+
+        // 최소 입찰단위 100원
+        if (bidPrice % 100 != 0) {
+            throw ServiceException.badRequest("입찰 금액은 100원 단위로 입력해주세요.");
+        }
+    }
+
+    private void updateProduct(Product product, Bid savedBid, Long newPrice) {
+        ProductChangeTracker tracker = ProductChangeTracker.of(product);
+
+        product.addBid(savedBid);
+        product.setCurrentPrice(newPrice);
+
+        productRepository.save(product); // 변경사항을 명시적으로 저장
+
+        tracker.publishChanges(eventPublisher, product);
+    }
+
+    private BidResponseDto createBidResponse(Bid bid) {
+        return new BidResponseDto(
+                bid.getId(),
+                bid.getProduct().getId(),
+                bid.getMember().getId(),
+                bid.getBidPrice(),
+                bid.getStatus(),
+                bid.getCreateDate()
+        );
+    }
+}

--- a/src/main/java/com/backend/domain/member/service/UserPresenceService.java
+++ b/src/main/java/com/backend/domain/member/service/UserPresenceService.java
@@ -1,0 +1,158 @@
+package com.backend.domain.member.service;
+
+import com.backend.global.redis.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 사용자 온라인/오프라인 상태 관리 서비스
+ * WebSocket 연결 상태와 Redis를 활용하여 사용자의 실시간 접속 상태를 추적
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserPresenceService {
+    
+    private final RedisUtil redisUtil;
+    
+    // WebSocket 세션과 사용자 이메일 매핑 (메모리 캐시)
+    private final ConcurrentHashMap<String, String> sessionUserMap = new ConcurrentHashMap<>();
+    
+    // 온라인 사용자 키 접두사
+    private static final String ONLINE_USER_KEY_PREFIX = "online:user:";
+    private static final String ONLINE_USERS_SET_KEY = "online:users";
+    
+    // 온라인 상태 TTL (5분 - 주기적으로 갱신됨)
+    private static final Duration ONLINE_STATUS_TTL = Duration.ofMinutes(5);
+    
+    /**
+     * 사용자를 온라인 상태로 설정
+     */
+    public void setUserOnline(String userEmail, String sessionId) {
+        try {
+            // Redis에 온라인 상태 저장
+            String userKey = ONLINE_USER_KEY_PREFIX + userEmail;
+            redisUtil.setDataExpire(userKey, sessionId, ONLINE_STATUS_TTL.toSeconds());
+            
+            // 온라인 사용자 Set에 추가
+            redisUtil.setSAdd(ONLINE_USERS_SET_KEY, userEmail);
+            
+            // 메모리 캐시에 저장
+            sessionUserMap.put(sessionId, userEmail);
+            
+            log.info("사용자 온라인 상태 설정: {} (세션: {})", userEmail, sessionId);
+        } catch (Exception e) {
+            log.error("사용자 온라인 상태 설정 실패: {}", userEmail, e);
+        }
+    }
+    
+    /**
+     * 사용자를 오프라인 상태로 설정
+     */
+    public void setUserOffline(String sessionId) {
+        try {
+            String userEmail = sessionUserMap.remove(sessionId);
+            
+            if (userEmail != null) {
+                // 다른 세션이 있는지 확인
+                boolean hasOtherSessions = sessionUserMap.values().stream()
+                    .anyMatch(email -> email.equals(userEmail));
+                
+                if (!hasOtherSessions) {
+                    // Redis에서 온라인 상태 제거
+                    String userKey = ONLINE_USER_KEY_PREFIX + userEmail;
+                    redisUtil.deleteData(userKey);
+                    
+                    // 온라인 사용자 Set에서 제거
+                    redisUtil.setSRem(ONLINE_USERS_SET_KEY, userEmail);
+                    
+                    log.info("사용자 오프라인 상태 설정: {} (세션: {})", userEmail, sessionId);
+                } else {
+                    log.debug("사용자 {}의 다른 세션이 존재함", userEmail);
+                }
+            }
+        } catch (Exception e) {
+            log.error("사용자 오프라인 상태 설정 실패: 세션 {}", sessionId, e);
+        }
+    }
+    
+    /**
+     * 사용자가 온라인인지 확인
+     */
+    public boolean isUserOnline(String userEmail) {
+        try {
+            String userKey = ONLINE_USER_KEY_PREFIX + userEmail;
+            return redisUtil.existData(userKey);
+        } catch (Exception e) {
+            log.error("사용자 온라인 상태 확인 실패: {}", userEmail, e);
+            return false;
+        }
+    }
+    
+    /**
+     * 사용자 ID로 온라인 상태 확인
+     */
+    public boolean isUserOnlineById(Long userId) {
+        // 이 메서드는 MemberRepository를 주입받아 이메일을 조회하는 로직이 필요
+        // 순환 참조를 피하기 위해 별도 처리 필요
+        return false;
+    }
+    
+    /**
+     * 온라인 사용자 목록 조회
+     */
+    public Set<Object> getOnlineUsers() {
+        try {
+            return redisUtil.setSMembers(ONLINE_USERS_SET_KEY);
+        } catch (Exception e) {
+            log.error("온라인 사용자 목록 조회 실패", e);
+            return Set.of();
+        }
+    }
+    
+    /**
+     * 사용자의 온라인 상태 갱신 (Heartbeat)
+     */
+    public void refreshUserOnlineStatus(String userEmail) {
+        try {
+            if (isUserOnline(userEmail)) {
+                String userKey = ONLINE_USER_KEY_PREFIX + userEmail;
+                redisUtil.setDataExpire(userKey, "active", ONLINE_STATUS_TTL.toSeconds());
+                log.debug("사용자 온라인 상태 갱신: {}", userEmail);
+            }
+        } catch (Exception e) {
+            log.error("사용자 온라인 상태 갱신 실패: {}", userEmail, e);
+        }
+    }
+    
+    /**
+     * 세션 ID로 사용자 이메일 조회
+     */
+    public String getUserEmailBySessionId(String sessionId) {
+        return sessionUserMap.get(sessionId);
+    }
+    
+    /**
+     * 모든 온라인 상태 초기화 (서버 재시작 시)
+     */
+    public void clearAllOnlineStatus() {
+        try {
+            Set<Object> onlineUsers = getOnlineUsers();
+            for (Object userEmail : onlineUsers) {
+                String userKey = ONLINE_USER_KEY_PREFIX + userEmail;
+                redisUtil.deleteData(userKey);
+            }
+            redisUtil.deleteData(ONLINE_USERS_SET_KEY);
+            sessionUserMap.clear();
+            
+            log.info("모든 온라인 상태 초기화 완료");
+        } catch (Exception e) {
+            log.error("온라인 상태 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/backend/domain/notification/service/NotificationProcessor.java
+++ b/src/main/java/com/backend/domain/notification/service/NotificationProcessor.java
@@ -1,24 +1,67 @@
 package com.backend.domain.notification.service;
 
+import com.backend.domain.member.service.UserPresenceService;
 import com.backend.domain.notification.entity.Notification;
+import com.backend.global.websocket.service.WebSocketService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
+/**
+ * 알림 처리기
+ * 사용자의 온라인/오프라인 상태에 따라 적절한 채널로 알림 전송
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationProcessor {
     
-    // 실제 알림 처리 로직
+    private final UserPresenceService userPresenceService;
+    private final WebSocketService webSocketService;
+
+    /**
+     * 알림 처리 - 온라인/오프라인 상태에 따라 적절한 채널로 전송
+     */
     public boolean processNotification(Notification notification) {
         try {
-            log.debug("알림 처리: type={}, member_id={}, message={}", 
+            String userEmail = notification.getMember().getEmail();
+            String message = notification.getMessage();
+
+            log.debug("알림 처리 시작: type={}, member_id={}, email={}",
                     notification.getNotificationType(),
-                    notification.getMember().getId(), 
-                    notification.getMessage());
-            // TODO: 나중에 푸시 알림 등 추가 가능
-            return true;
+                    notification.getMember().getId(),
+                    userEmail);
+
+            // 알림 데이터 구성
+            Map<String, Object> notificationData = Map.of(
+                    "notificationId", notification.getId(),
+                    "type", notification.getNotificationType(),
+                    "productId", notification.getProduct() != null ? notification.getProduct().getId() : "",
+                    "productName", notification.getProduct() != null ? notification.getProduct().getProductName() : "",
+                    "createdAt", notification.getCreateDate()
+            );
+
+            boolean isOnline = userPresenceService.isUserOnline(userEmail);
+
+            if (isOnline) {
+                // 온라인 상태: WebSocket으로 실시간 알림 전송
+                try {
+                    webSocketService.sendNotificationToUser(userEmail, message, notificationData);
+                    log.info("온라인 알림 전송 성공 - 사용자: {}, 타입: {}",
+                            userEmail, notification.getNotificationType());
+                    return true;
+                } catch (Exception e) {
+                    log.error("WebSocket 알림 전송 실패 - 사용자: {}", userEmail, e);
+                    return false;
+                }
+            } else {
+                // 오프라인 상태: 알림을 보내지 않음
+                log.info("사용자 오프라인 - 알림을 보내지 않음: {}", userEmail);
+                return true;
+            }
+
         } catch (Exception e) {
             log.error("알림 처리 중 예외 발생: notification_id={}", notification.getId(), e);
             return false;

--- a/src/main/java/com/backend/domain/product/repository/jpa/ProductRepository.java
+++ b/src/main/java/com/backend/domain/product/repository/jpa/ProductRepository.java
@@ -2,9 +2,13 @@ package com.backend.domain.product.repository.jpa;
 
 import com.backend.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
+    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.bids WHERE p.id = :id")
+    Optional<Product> findByIdWithBids(@Param("id") Long id);
     Optional<Product> findFirstByOrderByIdDesc();
 }

--- a/src/main/java/com/backend/global/initdata/TestInitData.java
+++ b/src/main/java/com/backend/global/initdata/TestInitData.java
@@ -1,7 +1,7 @@
 package com.backend.global.initdata;
 
-import com.backend.domain.bid.dto.BidRequestDto;
-import com.backend.domain.bid.service.BidService;
+import com.backend.domain.bid.dto.BidMessageDto;
+import com.backend.domain.bid.service.BidConsumerService;
 import com.backend.domain.member.dto.MemberSignUpRequestDto;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.service.MemberService;
@@ -33,7 +33,7 @@ public class TestInitData {
     private final StandardProductService productService;
     private final ProductImageService productImageService;
     private final MemberService memberService;
-    private final BidService bidService;
+    private final BidConsumerService bidConsumerService;
     private final ProductSyncService productSyncService;
 
     @Bean
@@ -124,17 +124,15 @@ public class TestInitData {
         Product product9 = productService.saveProduct(member4, requestDto9);
         productImageService.createProductImage(product9, "/image9_1.jpg");
 
-        // 입찰 생성 (분산락 없이)
-        createBidsWithoutLock(product4, product9, member1, member2);
+        // 입찰 생성
+        createBids(product4, product9, member1, member2);
     }
 
-    // 분산락 없이 입찰 생성
-    private void createBidsWithoutLock(Product product4, Product product9, Member member1, Member member2) {
+    private void createBids(Product product4, Product product9, Member member1, Member member2) {
+        bidConsumerService.processBid(new BidMessageDto(product4.getId(), member1.getId(), 1200000L));
+        bidConsumerService.processBid(new BidMessageDto(product4.getId(), member2.getId(), 1300000L));
 
-        bidService.createBidInternal(product4.getId(), member1.getId(), new BidRequestDto(1200000L));
-        bidService.createBidInternal(product4.getId(), member2.getId(), new BidRequestDto(1300000L));
-
-        bidService.createBidInternal(product9.getId(), member1.getId(), new BidRequestDto(900000L));
+        bidConsumerService.processBid(new BidMessageDto(product9.getId(), member1.getId(), 900000L));
 
         product9.setStatus("낙찰");
         product9.setEndTime(LocalDateTime.now());

--- a/src/main/java/com/backend/global/lock/DistributedLockAop.java
+++ b/src/main/java/com/backend/global/lock/DistributedLockAop.java
@@ -12,10 +12,13 @@ import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
 
+import org.springframework.core.annotation.Order;
+
 /**
  * @DistributedLock 선언 시 수행되는 Aop class
  */
 @Aspect
+@Order(1) // 트랜잭션 AOP보다 높은 우선순위를 부여
 @Component
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/backend/global/redis/RedisUtil.java
+++ b/src/main/java/com/backend/global/redis/RedisUtil.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -22,5 +23,26 @@ public class RedisUtil {
 
     public void deleteData(String key) {
         redisTemplate.delete(key);
+    }
+
+    public void setDataExpire(String key, Object value, Long expiredTimeSeconds) {
+        redisTemplate.opsForValue().set(key, value, expiredTimeSeconds, TimeUnit.SECONDS);
+    }
+
+    public Boolean existData(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    public Long setSAdd(String key, Object... values) {
+        return redisTemplate.opsForSet().add(key, values);
+    }
+
+    public Long setSRem(String key, Object... values) {
+        return redisTemplate.opsForSet().remove(key, values);
+    }
+
+    public Set<Object> setSMembers(String key) {
+        Set<Object> members = redisTemplate.opsForSet().members(key);
+        return members != null ? members : Set.of();
     }
 }

--- a/src/main/java/com/backend/global/scheduler/UserPresenceCleanupScheduler.java
+++ b/src/main/java/com/backend/global/scheduler/UserPresenceCleanupScheduler.java
@@ -1,0 +1,45 @@
+package com.backend.global.scheduler;
+
+import com.backend.domain.member.service.UserPresenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 사용자 온라인 상태 정리 스케줄러
+ * 만료된 온라인 상태를 주기적으로 정리
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserPresenceCleanupScheduler {
+    
+    private final UserPresenceService userPresenceService;
+    
+    /**
+     * 애플리케이션 시작 시 모든 온라인 상태 초기화
+     * 서버 재시작 시 이전 세션 정보를 정리
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        log.info("애플리케이션 시작 - 사용자 온라인 상태 초기화");
+        userPresenceService.clearAllOnlineStatus();
+    }
+    
+    /**
+     * 주기적으로 온라인 사용자 수 로깅 (모니터링용)
+     * 10분마다 실행
+     */
+    @Scheduled(fixedDelay = 600000) // 10분
+    public void logOnlineUsersCount() {
+        try {
+            int onlineCount = userPresenceService.getOnlineUsers().size();
+            log.info("현재 온라인 사용자 수: {}", onlineCount);
+        } catch (Exception e) {
+            log.error("온라인 사용자 수 조회 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/backend/global/websocket/controller/HeartbeatController.java
+++ b/src/main/java/com/backend/global/websocket/controller/HeartbeatController.java
@@ -1,0 +1,65 @@
+package com.backend.global.websocket.controller;
+
+import com.backend.domain.member.service.UserPresenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * WebSocket Heartbeat 컨트롤러
+ * 클라이언트의 연결 상태를 주기적으로 확인
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class HeartbeatController {
+    
+    private final UserPresenceService userPresenceService;
+    
+    /**
+     * 클라이언트로부터 heartbeat 수신 및 응답
+     * 클라이언트는 주기적으로 이 엔드포인트로 메시지를 전송하여 연결 상태를 유지
+     */
+    @MessageMapping("/heartbeat")
+    @SendToUser("/queue/heartbeat")
+    public Map<String, Object> handleHeartbeat(Authentication authentication) {
+        if (authentication != null && authentication.isAuthenticated()) {
+            String userEmail = authentication.getName();
+            
+            // 사용자 온라인 상태 갱신
+            userPresenceService.refreshUserOnlineStatus(userEmail);
+            
+            log.debug("Heartbeat 수신 - 사용자: {}", userEmail);
+            
+            return Map.of(
+                "status", "alive",
+                "timestamp", LocalDateTime.now().toString(),
+                "user", userEmail
+            );
+        }
+        
+        return Map.of(
+            "status", "unauthorized",
+            "timestamp", LocalDateTime.now().toString()
+        );
+    }
+    
+    /**
+     * 전체 heartbeat 브로드캐스트 (서버 상태 확인용)
+     */
+    @MessageMapping("/ping")
+    @SendTo("/topic/pong")
+    public Map<String, Object> handlePing() {
+        return Map.of(
+            "status", "pong",
+            "serverTime", LocalDateTime.now().toString()
+        );
+    }
+}

--- a/src/main/java/com/backend/global/websocket/listener/WebSocketEventListener.java
+++ b/src/main/java/com/backend/global/websocket/listener/WebSocketEventListener.java
@@ -1,0 +1,78 @@
+package com.backend.global.websocket.listener;
+
+import com.backend.domain.member.service.UserPresenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+/**
+ * WebSocket 세션 이벤트 리스너
+ * 사용자의 WebSocket 연결/해제를 감지하고 온라인 상태를 관리
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketEventListener {
+    
+    private final UserPresenceService userPresenceService;
+    
+    /**
+     * WebSocket 연결 이벤트 처리
+     */
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        
+        if (headerAccessor.getUser() != null && headerAccessor.getUser() instanceof UsernamePasswordAuthenticationToken) {
+            UsernamePasswordAuthenticationToken authentication = 
+                (UsernamePasswordAuthenticationToken) headerAccessor.getUser();
+            
+            String userEmail = authentication.getName();
+            String sessionId = headerAccessor.getSessionId();
+            
+            // 사용자를 온라인 상태로 설정
+            userPresenceService.setUserOnline(userEmail, sessionId);
+            
+            log.info("WebSocket 연결 - 사용자: {}, 세션: {}", userEmail, sessionId);
+        }
+    }
+    
+    /**
+     * WebSocket 연결 해제 이벤트 처리
+     */
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+        
+        // 사용자를 오프라인 상태로 설정
+        userPresenceService.setUserOffline(sessionId);
+        
+        log.info("WebSocket 연결 해제 - 세션: {}", sessionId);
+    }
+    
+    /**
+     * WebSocket 구독 이벤트 처리 (옵션)
+     * 특정 토픽 구독 시 추가 처리가 필요한 경우 사용
+     */
+    @EventListener
+    public void handleWebSocketSubscribeListener(SessionSubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        
+        if (headerAccessor.getUser() != null) {
+            String destination = headerAccessor.getDestination();
+            String userEmail = headerAccessor.getUser().getName();
+            
+            log.debug("WebSocket 구독 - 사용자: {}, 대상: {}", userEmail, destination);
+            
+            // 사용자 온라인 상태 갱신 (Heartbeat 역할)
+            userPresenceService.refreshUserOnlineStatus(userEmail);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,8 @@ app:
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
+
+
 management:
   endpoints:
     web:

--- a/src/main/resources/static/websocket-with-heartbeat.html
+++ b/src/main/resources/static/websocket-with-heartbeat.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>WebSocket with Heartbeat & Offline Notification</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body {
+            font-family: 'Malgun Gothic', sans-serif;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .status {
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+            font-weight: bold;
+        }
+        .online {
+            background-color: #d4edda;
+            color: #155724;
+        }
+        .offline {
+            background-color: #f8d7da;
+            color: #721c24;
+        }
+        .connecting {
+            background-color: #fff3cd;
+            color: #856404;
+        }
+        .notification {
+            padding: 15px;
+            margin: 10px 0;
+            border-left: 4px solid #4CAF50;
+            background-color: #f9f9f9;
+            border-radius: 4px;
+        }
+        .notification.email {
+            border-left-color: #2196F3;
+        }
+        .notification .time {
+            font-size: 12px;
+            color: #666;
+        }
+        .controls {
+            margin: 20px 0;
+        }
+        button {
+            padding: 10px 20px;
+            margin: 5px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        .btn-connect {
+            background-color: #4CAF50;
+            color: white;
+        }
+        .btn-disconnect {
+            background-color: #f44336;
+            color: white;
+        }
+        .btn-test {
+            background-color: #2196F3;
+            color: white;
+        }
+        #messages {
+            max-height: 400px;
+            overflow-y: auto;
+            border: 1px solid #ddd;
+            padding: 10px;
+            border-radius: 4px;
+            background-color: #fafafa;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>WebSocket with Heartbeat & Offline Notification Test</h1>
+        
+        <div id="connectionStatus" class="status offline">
+            연결 상태: 오프라인
+        </div>
+        
+        <div class="controls">
+            <button id="connectBtn" class="btn-connect">연결</button>
+            <button id="disconnectBtn" class="btn-disconnect">연결 해제</button>
+            <button id="testNotificationBtn" class="btn-test">테스트 알림 전송</button>
+            <button id="clearBtn" class="btn-test">메시지 지우기</button>
+        </div>
+        
+        <div>
+            <h3>JWT 토큰 (테스트용)</h3>
+            <input type="text" id="jwtToken" placeholder="Bearer token..." style="width: 100%; padding: 8px;">
+        </div>
+        
+        <h3>수신 알림:</h3>
+        <div id="messages"></div>
+        
+        <div style="margin-top: 20px; padding: 15px; background-color: #e8f4f8; border-radius: 4px;">
+            <h4>기능 설명:</h4>
+            <ul>
+                <li><strong>온라인 상태:</strong> WebSocket 연결 시 실시간 알림 수신</li>
+                <li><strong>오프라인 상태:</strong> 연결 해제 시 이메일로 알림 전송</li>
+                <li><strong>Heartbeat:</strong> 30초마다 연결 상태 확인 (자동)</li>
+                <li><strong>재연결:</strong> 연결 끊김 시 자동 재연결 시도</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        let stompClient = null;
+        let heartbeatInterval = null;
+        let reconnectAttempts = 0;
+        const MAX_RECONNECT_ATTEMPTS = 5;
+        const HEARTBEAT_INTERVAL = 30000; // 30초
+        const RECONNECT_DELAY = 3000; // 3초
+        
+        // 연결 상태 업데이트
+        function updateConnectionStatus(status) {
+            const statusDiv = document.getElementById('connectionStatus');
+            statusDiv.className = 'status ' + status;
+            
+            switch(status) {
+                case 'online':
+                    statusDiv.textContent = '연결 상태: 온라인 ✅';
+                    break;
+                case 'offline':
+                    statusDiv.textContent = '연결 상태: 오프라인 ❌';
+                    break;
+                case 'connecting':
+                    statusDiv.textContent = '연결 상태: 연결 중... ⏳';
+                    break;
+            }
+        }
+        
+        // 메시지 추가
+        function addMessage(type, content, isEmail = false) {
+            const messagesDiv = document.getElementById('messages');
+            const messageDiv = document.createElement('div');
+            messageDiv.className = 'notification' + (isEmail ? ' email' : '');
+            
+            const now = new Date().toLocaleString('ko-KR');
+            messageDiv.innerHTML = `
+                <strong>${type}</strong>: ${content}
+                <div class="time">${now} ${isEmail ? '(이메일 전송됨)' : '(실시간)'}</div>
+            `;
+            
+            messagesDiv.insertBefore(messageDiv, messagesDiv.firstChild);
+        }
+        
+        // WebSocket 연결
+        function connect() {
+            updateConnectionStatus('connecting');
+            
+            const token = document.getElementById('jwtToken').value || 'test-token';
+            const socket = new SockJS('/ws');
+            stompClient = Stomp.over(socket);
+            
+            // 디버그 로그 비활성화
+            stompClient.debug = null;
+            
+            const headers = {
+                'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token
+            };
+            
+            stompClient.connect(headers, function (frame) {
+                console.log('Connected: ' + frame);
+                updateConnectionStatus('online');
+                reconnectAttempts = 0;
+                
+                // 개인 알림 구독
+                stompClient.subscribe('/user/queue/notifications', function (message) {
+                    const notification = JSON.parse(message.body);
+                    addMessage('개인 알림', notification.content);
+                    console.log('개인 알림 수신:', notification);
+                });
+                
+                // Heartbeat 응답 구독
+                stompClient.subscribe('/user/queue/heartbeat', function (message) {
+                    const response = JSON.parse(message.body);
+                    console.log('Heartbeat 응답:', response);
+                });
+                
+                // 전체 pong 구독 (서버 상태 확인)
+                stompClient.subscribe('/topic/pong', function (message) {
+                    const response = JSON.parse(message.body);
+                    console.log('서버 Pong:', response);
+                });
+                
+                // 테스트용 토픽 구독
+                stompClient.subscribe('/topic/test', function (message) {
+                    const msg = JSON.parse(message.body);
+                    addMessage('브로드캐스트', msg.content);
+                });
+                
+                // Heartbeat 시작
+                startHeartbeat();
+                
+                addMessage('시스템', '✅ WebSocket 연결 성공!');
+                
+            }, function (error) {
+                console.error('연결 실패:', error);
+                updateConnectionStatus('offline');
+                addMessage('시스템', '❌ 연결 실패: ' + error);
+                
+                // 재연결 시도
+                attemptReconnect();
+            });
+        }
+        
+        // WebSocket 연결 해제
+        function disconnect() {
+            if (stompClient !== null) {
+                stopHeartbeat();
+                stompClient.disconnect(function() {
+                    updateConnectionStatus('offline');
+                    addMessage('시스템', '연결이 해제되었습니다.');
+                });
+            }
+            stompClient = null;
+        }
+        
+        // Heartbeat 시작
+        function startHeartbeat() {
+            stopHeartbeat(); // 기존 heartbeat 정지
+            
+            heartbeatInterval = setInterval(function() {
+                if (stompClient && stompClient.connected) {
+                    stompClient.send("/app/heartbeat", {}, JSON.stringify({}));
+                    console.log('Heartbeat 전송');
+                }
+            }, HEARTBEAT_INTERVAL);
+        }
+        
+        // Heartbeat 정지
+        function stopHeartbeat() {
+            if (heartbeatInterval) {
+                clearInterval(heartbeatInterval);
+                heartbeatInterval = null;
+            }
+        }
+        
+        // 재연결 시도
+        function attemptReconnect() {
+            if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+                reconnectAttempts++;
+                addMessage('시스템', `재연결 시도 중... (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`);
+                
+                setTimeout(function() {
+                    connect();
+                }, RECONNECT_DELAY);
+            } else {
+                addMessage('시스템', '❌ 재연결 실패. 수동으로 다시 연결해주세요.');
+                addMessage('시스템', '📧 오프라인 상태입니다. 중요한 알림은 이메일로 전송됩니다.');
+            }
+        }
+        
+        // 테스트 알림 전송
+        function sendTestNotification() {
+            if (stompClient && stompClient.connected) {
+                const testMessage = {
+                    type: 'TEST',
+                    sender: 'test-user',
+                    content: '테스트 알림: ' + new Date().toLocaleTimeString(),
+                    data: {
+                        productId: 1,
+                        productName: '테스트 상품'
+                    }
+                };
+                
+                stompClient.send("/app/test", {}, JSON.stringify(testMessage));
+                addMessage('전송', '테스트 메시지 전송됨');
+            } else {
+                addMessage('시스템', '❌ 연결되지 않음. 오프라인 상태에서는 이메일로 알림이 전송됩니다.');
+            }
+        }
+        
+        // 메시지 지우기
+        function clearMessages() {
+            document.getElementById('messages').innerHTML = '';
+        }
+        
+        // 이벤트 리스너
+        document.getElementById('connectBtn').addEventListener('click', connect);
+        document.getElementById('disconnectBtn').addEventListener('click', disconnect);
+        document.getElementById('testNotificationBtn').addEventListener('click', sendTestNotification);
+        document.getElementById('clearBtn').addEventListener('click', clearMessages);
+        
+        // 페이지 로드 시 자동 연결 (옵션)
+        // window.onload = connect;
+        
+        // 페이지 종료 시 연결 해제
+        window.onbeforeunload = function() {
+            disconnect();
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
 ### 주요 변경사항
실시간 알림 및 사용자 접속 상태 감지 :WebSocket과 Redis 연동하여 사용자의 온/오프라인을 감지하고, 온라인 사용자에게만 실시간 알림을 전송
비동기 입찰 처리: 기존의 동기 방식 입찰 처리를 Redis 메시지 큐를 이용한 비동기 방식으로 변경 -> 사용자 요청에 대한 응답 시간을 단축하고 시스템 처리량을 향상

**UserPresenceService:** WebSocket 세션과 Redis를 이용해 사용자의 실시간 온/오프라인 상태를 추적하고 관리
**NotificationProcessor:** `UserPresenceService`를 사용하여 사용자의 온라인 상태를 확인하고, 온라인 상태일 경우에만 WebSocket을 통해 실시간 알림을 전송하도록 수정
**HeartbeatController:** 클라이언트가 주기적으로 호출하여 WebSocket 연결을 유지하고, `UserPresenceService`를 통해 온라인 상태를 갱신하는 `/heartbeat` 엔드포인트를 구현
**WebSocketEventListener:** WebSocket 연결 및 해제 이벤트를 감지하여 `UserPresenceService`의 온라인/오프라인 상태를 자동으로 업데이트하는 리스너
**UserPresenceCleanupScheduler:** 애플리케이션 시작 시 모든 온라인 상태를 초기화하고, 주기적으로 온라인 사용자 수를 로깅하는 스케줄러
**RedisUtil:** `UserPresenceService`에서 사용자 온라인 상태 관리에 필요한 Redis Set 관련 메서드 및 유틸리티 메서드를 추가
**BidService:** `createBid` 메서드를 수정하여, 입찰 요청을 동기 처리하는 대신 Redis 메시지 큐에 추가하고 '요청 접수됨(202)' 상태를 즉시 응답하도록 변경
**BidConsumerService:** Redis의 `bid_queue`에서 입찰 메시지를 비동기적으로 처리하는 서비스. 분산 락을 사용하여 입찰 처리의 동시성을 제어
**BidMessageDto:** 비동기 입찰 처리를 위해 Redis 메시지 큐에서 사용될 DTO
**DistributedLockAop:** `@Order(1)`을 추가하여 분산 락 AOP가 트랜잭션 AOP보다 먼저 실행되도록 우선순위를 설정
**ProductRepository:** N+1 문제를 방지하기 위해 `bids` 컬렉션을 즉시 로딩하는 `findByIdWithBids` 메서드를 추가(`FETCH JOIN` 사용)
**TestInitData:** 테스트 데이터 생성 시, 새로운 비동기 입찰 방식인 `BidConsumerService.processBid`를 사용하도록 수정
**BidDistributedLockPerformanceTest:** 비동기 입찰 시스템을 테스트하도록 대폭 수정. API 성공여부와 최종 DB 데이터 정합성을 분리하여 검증